### PR TITLE
Left Drawer Fix with About and Contact Page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import CheckoutPage from "./CheckoutPage";
 import ProfilePage from "./ProfilePage";
 import ProductPage from "./ProductPage";
 import OrderStatusPage from "./OrderStatusPage";
+import ContactPage from "./ContactPage";
 
 function App() {
   return (
@@ -36,6 +37,7 @@ function App() {
             </ProtectedRoute>
           }
         />
+        <Route path="/contact" element={<ContactPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/ContactPage.css
+++ b/frontend/src/ContactPage.css
@@ -1,0 +1,15 @@
+.contact-container {
+    text-align: center;
+    padding: 20px;
+  }
+  
+  .drawer-icon {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+  }
+  
+  .contact-content {
+    margin-top: 100px;
+    font-size: 24px;
+  }

--- a/frontend/src/ContactPage.css
+++ b/frontend/src/ContactPage.css
@@ -1,15 +1,15 @@
 .contact-container {
     text-align: center;
     padding: 20px;
-  }
-  
-  .drawer-icon {
+}
+
+.drawer-icon {
     position: absolute;
     top: 20px;
     left: 20px;
-  }
-  
-  .contact-content {
+}
+
+.contact-content {
     margin-top: 100px;
     font-size: 24px;
-  }
+}

--- a/frontend/src/ContactPage.js
+++ b/frontend/src/ContactPage.js
@@ -14,7 +14,7 @@ const ContactPage = () => {
       <Box className="contact-content">
         <Typography variant="h4">Contact Us</Typography>
         <Typography variant="body1" sx={{ marginTop: "20px" }}>
-          You can send an email to <strong>we don't have an email yet :)</strong> for any inquiries.
+          You can send an email to <strong>cs308team9@gmail.com</strong> for any inquiries.
         </Typography>
       </Box>
     </Box>

--- a/frontend/src/ContactPage.js
+++ b/frontend/src/ContactPage.js
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import { Typography, Box, Drawer, List, ListItem, ListItemText, IconButton } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import { useNavigate } from "react-router-dom";
+import "./ContactPage.css";
+import DrawerMenu from "./components/DrawerMenu";
 
 const ContactPage = () => {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -12,52 +14,15 @@ const ContactPage = () => {
   };
 
   return (
-    <Box>
-      <IconButton edge="start" color="inherit" onClick={toggleDrawer(true)}>
-        <MenuIcon />
-      </IconButton>
-
-      <Drawer anchor="left" open={drawerOpen} onClose={toggleDrawer(false)}>
-        <List sx={{ width: 250 }}>
-          <ListItem
-            button
-            sx={{ cursor: "pointer" }}
-            onClick={() => {
-              navigate("/");
-              setDrawerOpen(false); // Close the drawer
-            }}
-          >
-            <ListItemText primary="Home" />
-          </ListItem>
-          <ListItem
-            button
-            sx={{ cursor: "pointer" }}
-            onClick={() => {
-              window.open("https://github.com/KouroshKSH/cs308-project", "_blank");
-              setDrawerOpen(false); // Close the drawer
-            }}
-          >
-            <ListItemText primary="About" />
-          </ListItem>
-          <ListItem
-            button
-            sx={{ cursor: "pointer" }}
-            onClick={() => {
-              navigate("/contact");
-              setDrawerOpen(false); // Close the drawer
-            }}
-          >
-            <ListItemText primary="Contact" />
-          </ListItem>
-        </List>
-      </Drawer>
-
-      <Box sx={{ textAlign: "center", marginTop: "50px" }}>
+    <Box className="contact-container">
+    {/* the custom drawer menu component */}
+    <DrawerMenu />
+    <Box className="contact-content">
         <Typography variant="h4">Contact Us</Typography>
         <Typography variant="body1" sx={{ marginTop: "20px" }}>
-          You can send an email to <strong>we don't have an email yet :)</strong> for any inquiries.
+        You can send an email to <strong>we don't have an email yet :)</strong> for any inquiries.
         </Typography>
-      </Box>
+    </Box>
     </Box>
   );
 };

--- a/frontend/src/ContactPage.js
+++ b/frontend/src/ContactPage.js
@@ -1,30 +1,25 @@
 import React, { useState } from "react";
-import { Typography, Box, Drawer, List, ListItem, ListItemText, IconButton } from "@mui/material";
-import MenuIcon from "@mui/icons-material/Menu";
+import { Typography, Box } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import "./ContactPage.css";
 import DrawerMenu from "./components/DrawerMenu";
 
 const ContactPage = () => {
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const navigate = useNavigate();
-
-  const toggleDrawer = (open) => () => {
-    setDrawerOpen(open);
-  };
 
   return (
     <Box className="contact-container">
-    {/* the custom drawer menu component */}
-    <DrawerMenu />
-    <Box className="contact-content">
+      {/* Position the DrawerMenu at the top-left corner */}
+      <Box className="drawer-icon">
+        <DrawerMenu />
+      </Box>
+      <Box className="contact-content">
         <Typography variant="h4">Contact Us</Typography>
         <Typography variant="body1" sx={{ marginTop: "20px" }}>
-        You can send an email to <strong>we don't have an email yet :)</strong> for any inquiries.
+          You can send an email to <strong>we don't have an email yet :)</strong> for any inquiries.
         </Typography>
+      </Box>
     </Box>
-    </Box>
-  );
+    );
 };
 
 export default ContactPage;

--- a/frontend/src/ContactPage.js
+++ b/frontend/src/ContactPage.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { Typography, Box } from "@mui/material";
+
+const ContactPage = () => {
+  return (
+    <Box sx={{ textAlign: "center", marginTop: "50px" }}>
+      <Typography variant="h4">Contact Us</Typography>
+      <Typography variant="body1" sx={{ marginTop: "20px" }}>
+        You can send an email to <strong>no email yet :)</strong> for any inquiries.
+      </Typography>
+    </Box>
+  );
+};
+
+export default ContactPage;

--- a/frontend/src/ContactPage.js
+++ b/frontend/src/ContactPage.js
@@ -1,13 +1,63 @@
-import React from "react";
-import { Typography, Box } from "@mui/material";
+import React, { useState } from "react";
+import { Typography, Box, Drawer, List, ListItem, ListItemText, IconButton } from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
+import { useNavigate } from "react-router-dom";
 
 const ContactPage = () => {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const toggleDrawer = (open) => () => {
+    setDrawerOpen(open);
+  };
+
   return (
-    <Box sx={{ textAlign: "center", marginTop: "50px" }}>
-      <Typography variant="h4">Contact Us</Typography>
-      <Typography variant="body1" sx={{ marginTop: "20px" }}>
-        You can send an email to <strong>no email yet :)</strong> for any inquiries.
-      </Typography>
+    <Box>
+      <IconButton edge="start" color="inherit" onClick={toggleDrawer(true)}>
+        <MenuIcon />
+      </IconButton>
+
+      <Drawer anchor="left" open={drawerOpen} onClose={toggleDrawer(false)}>
+        <List sx={{ width: 250 }}>
+          <ListItem
+            button
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              navigate("/");
+              setDrawerOpen(false); // Close the drawer
+            }}
+          >
+            <ListItemText primary="Home" />
+          </ListItem>
+          <ListItem
+            button
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              window.open("https://github.com/KouroshKSH/cs308-project", "_blank");
+              setDrawerOpen(false); // Close the drawer
+            }}
+          >
+            <ListItemText primary="About" />
+          </ListItem>
+          <ListItem
+            button
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              navigate("/contact");
+              setDrawerOpen(false); // Close the drawer
+            }}
+          >
+            <ListItemText primary="Contact" />
+          </ListItem>
+        </List>
+      </Drawer>
+
+      <Box sx={{ textAlign: "center", marginTop: "50px" }}>
+        <Typography variant="h4">Contact Us</Typography>
+        <Typography variant="body1" sx={{ marginTop: "20px" }}>
+          You can send an email to <strong>we don't have an email yet :)</strong> for any inquiries.
+        </Typography>
+      </Box>
     </Box>
   );
 };

--- a/frontend/src/ContactPage.js
+++ b/frontend/src/ContactPage.js
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
+import React from "react";
 import { Typography, Box } from "@mui/material";
-import { useNavigate } from "react-router-dom";
 import "./ContactPage.css";
 import DrawerMenu from "./components/DrawerMenu";
 
@@ -20,6 +19,7 @@ const ContactPage = () => {
       </Box>
     </Box>
     );
+    // maybe @reyhanturhan can provide the email address once she makes it
 };
 
 export default ContactPage;

--- a/frontend/src/LandingPage.css
+++ b/frontend/src/LandingPage.css
@@ -1,4 +1,3 @@
-/* LandingPage.css */
 .landing-container {
     text-align: center;
     padding: 20px;

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -184,10 +184,10 @@ const LandingPage = () => {
 
       <Drawer anchor="left" open={drawerOpen} onClose={toggleDrawer(false)}>
         <List sx={{ width: 250 }}>
-          <ListItem button>
+          <ListItem button onClick={() => navigate("/")}>
             <ListItemText primary="Home" />
           </ListItem>
-          <ListItem button>
+          <ListItem button onClick={() => (window.location.href = "https://github.com/KouroshKSH/cs308-project")}>
             <ListItemText primary="About" />
           </ListItem>
           <ListItem button>

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -11,7 +11,6 @@ import {
 } from "@mui/material";
 import { useNavigate, Link } from "react-router-dom";
 import axios from "axios"; // we'll need it for API calls
-import MenuIcon from "@mui/icons-material/Menu";
 import SearchIcon from "@mui/icons-material/Search";
 import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 import AccountCircle from "@mui/icons-material/AccountCircle";
@@ -142,7 +141,7 @@ const LandingPage = () => {
     <div className="landing-container">
       <AppBar position="absolute" color="transparent" elevation={0}>
         <Toolbar sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          {/* Use DrawerMenu here */}
+          {/* the custom drawer component */}
           <DrawerMenu />
 
           { /*  changes the department based on what you click  */}

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -190,7 +190,7 @@ const LandingPage = () => {
           <ListItem button onClick={() => (window.location.href = "https://github.com/KouroshKSH/cs308-project")}>
             <ListItemText primary="About" />
           </ListItem>
-          <ListItem button>
+          <ListItem button onClick={() => navigate("/contact")}>
             <ListItemText primary="Contact" />
           </ListItem>
         </List>

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -5,10 +5,6 @@ import {
   Typography,
   IconButton,
   Box,
-  Drawer,
-  List,
-  ListItem,
-  ListItemText,
   Menu,
   MenuItem,
   Button,
@@ -20,6 +16,8 @@ import SearchIcon from "@mui/icons-material/Search";
 import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 import AccountCircle from "@mui/icons-material/AccountCircle";
 import "./LandingPage.css";
+import DrawerMenu from "./components/DrawerMenu";
+
 
 // Import images
 // import product1 from "./assets/images/product1.avif"; // and so on
@@ -144,10 +142,8 @@ const LandingPage = () => {
     <div className="landing-container">
       <AppBar position="absolute" color="transparent" elevation={0}>
         <Toolbar sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <IconButton edge="start" color="inherit" onClick={toggleDrawer(true)}>
-            <MenuIcon />
-          </IconButton>
-
+          {/* Use DrawerMenu here */}
+          <DrawerMenu />
 
           { /*  changes the department based on what you click  */}
           <Box sx={{ display: "flex", gap: 4, flexGrow: 1, justifyContent: "center" }}>
@@ -181,41 +177,6 @@ const LandingPage = () => {
           </Box>
         </Toolbar>
       </AppBar>
-
-      <Drawer anchor="left" open={drawerOpen} onClose={toggleDrawer(false)}>
-        <List sx={{ width: 250 }}>
-          <ListItem
-            button
-            sx={{ cursor: "pointer" }}
-            onClick={() => {
-              navigate("/");
-              setDrawerOpen(false); // Close the drawer
-            }}
-          >
-            <ListItemText primary="Home" />
-          </ListItem>
-          <ListItem
-            button
-            sx={{ cursor: "pointer" }}
-            onClick={() => {
-              window.open("https://github.com/KouroshKSH/cs308-project", "_blank");
-              setDrawerOpen(false); // Close the drawer
-            }}
-          >
-            <ListItemText primary="About" />
-          </ListItem>
-          <ListItem
-            button
-            sx={{ cursor: "pointer" }}
-            onClick={() => {
-              navigate("/contact");
-              setDrawerOpen(false); // Close the drawer
-            }}
-          >
-            <ListItemText primary="Contact" />
-          </ListItem>
-        </List>
-      </Drawer>
 
       <main className="landing-content">
         <Typography variant="h2">{department} Collection</Typography>

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -184,13 +184,34 @@ const LandingPage = () => {
 
       <Drawer anchor="left" open={drawerOpen} onClose={toggleDrawer(false)}>
         <List sx={{ width: 250 }}>
-          <ListItem button onClick={() => navigate("/")}>
+          <ListItem
+            button
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              navigate("/");
+              setDrawerOpen(false); // Close the drawer
+            }}
+          >
             <ListItemText primary="Home" />
           </ListItem>
-          <ListItem button onClick={() => (window.location.href = "https://github.com/KouroshKSH/cs308-project")}>
+          <ListItem
+            button
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              window.open("https://github.com/KouroshKSH/cs308-project", "_blank");
+              setDrawerOpen(false); // Close the drawer
+            }}
+          >
             <ListItemText primary="About" />
           </ListItem>
-          <ListItem button onClick={() => navigate("/contact")}>
+          <ListItem
+            button
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              navigate("/contact");
+              setDrawerOpen(false); // Close the drawer
+            }}
+          >
             <ListItemText primary="Contact" />
           </ListItem>
         </List>

--- a/frontend/src/components/DrawerMenu.js
+++ b/frontend/src/components/DrawerMenu.js
@@ -1,4 +1,3 @@
-// filepath: /home/kourosh/Documents/Sabanci/classes/cs308/cs308-project/frontend/src/components/DrawerMenu.js
 import React, { useState } from "react";
 import { Drawer, List, ListItem, ListItemText, IconButton } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
@@ -34,6 +33,8 @@ const DrawerMenu = () => {
             button
             sx={{ cursor: "pointer" }}
             onClick={() => {
+              // I chose our project's GitHub link as the "About" page
+              // because we don't have a dedicated About page yet.
               window.open("https://github.com/KouroshKSH/cs308-project", "_blank");
               setDrawerOpen(false); // Close the drawer
             }}
@@ -44,6 +45,7 @@ const DrawerMenu = () => {
             button
             sx={{ cursor: "pointer" }}
             onClick={() => {
+              // goes to a basic contact page, nothing special
               navigate("/contact");
               setDrawerOpen(false); // Close the drawer
             }}

--- a/frontend/src/components/DrawerMenu.js
+++ b/frontend/src/components/DrawerMenu.js
@@ -1,0 +1,59 @@
+// filepath: /home/kourosh/Documents/Sabanci/classes/cs308/cs308-project/frontend/src/components/DrawerMenu.js
+import React, { useState } from "react";
+import { Drawer, List, ListItem, ListItemText, IconButton } from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
+import { useNavigate } from "react-router-dom";
+
+const DrawerMenu = () => {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const toggleDrawer = (open) => () => {
+    setDrawerOpen(open);
+  };
+
+  return (
+    <>
+      <IconButton edge="start" color="inherit" onClick={toggleDrawer(true)}>
+        <MenuIcon />
+      </IconButton>
+
+      <Drawer anchor="left" open={drawerOpen} onClose={toggleDrawer(false)}>
+        <List sx={{ width: 250 }}>
+          <ListItem
+            button
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              navigate("/");
+              setDrawerOpen(false); // Close the drawer
+            }}
+          >
+            <ListItemText primary="Home" />
+          </ListItem>
+          <ListItem
+            button
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              window.open("https://github.com/KouroshKSH/cs308-project", "_blank");
+              setDrawerOpen(false); // Close the drawer
+            }}
+          >
+            <ListItemText primary="About" />
+          </ListItem>
+          <ListItem
+            button
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              navigate("/contact");
+              setDrawerOpen(false); // Close the drawer
+            }}
+          >
+            <ListItemText primary="Contact" />
+          </ListItem>
+        </List>
+      </Drawer>
+    </>
+  );
+};
+
+export default DrawerMenu;


### PR DESCRIPTION
# Overview
Our left drawer is now functional, regarding #54 .
@ArifSari-maker If all checks out, feel free to merge it or approve for merging.

## Info
1. It now has clickable items, unlike before.
2. It redirects the user if the click:
    a. "Home" to landing page 
    b. "About" to our project's GitHub page
    c. "Contact" to a contact page
3. It collapses automatically
4. It can be used on any page since it's a component now, as `frontend/src/components/DrawerMenu.js`
5. We can later change its behavior and have the updates reflected on any page that uses it

## Screenshots
### How it looks
![image](https://github.com/user-attachments/assets/c4062c4e-6a9e-4d0d-b226-67e9e5fcadec)

### Clickable items
![Screenshot from 2025-04-17 01-48-59](https://github.com/user-attachments/assets/3169743d-0d4d-4494-aec9-146d6fa5d611)

### Redirection to GitHub
Opens a new tab and redirects the user to our [project's page](https://github.com/KouroshKSH/cs308-project). The logic behind is:

```js
          <ListItem
            button
            sx={{ cursor: "pointer" }}
            onClick={() => {
              // I chose our project's GitHub link as the "About" page
              // because we don't have a dedicated About page yet.
              window.open("https://github.com/KouroshKSH/cs308-project", "_blank");
              setDrawerOpen(false); // Close the drawer
            }}
          >
```

### Contact page
![image](https://github.com/user-attachments/assets/3791c39a-4884-4632-9661-64c6ca475621)

> This page also has the drawer. Basically all pages can have a drawer now.