### PR TITLE
Updating stock after purchase

### DIFF
--- a/backend/src/controllers/orderController.js
+++ b/backend/src/controllers/orderController.js
@@ -42,7 +42,7 @@ exports.createOrder = async (req, res) => {
       // Creating the order item
       await OrderItem.create({ order_id: orderId, product_id, variation_id, quantity, price_at_purchase });
 
-      // 3. Decrementing stock
+      // Decrementing stock
       const newStock = variation.stock_quantity - quantity;
       await pool.query(
         `UPDATE product_variations SET stock_quantity = ? WHERE variation_id = ?`,

--- a/backend/src/controllers/orderController.js
+++ b/backend/src/controllers/orderController.js
@@ -12,10 +12,10 @@ exports.createOrder = async (req, res) => {
       return res.status(400).json({ error: "Missing required fields" });
     }
 
-    // Create the order
+    // Creating order
     const orderId = await Order.create({ user_id, delivery_address, total_price });
 
-    // Loop through the order items to create them and update stock
+    // Going through order items to create them and to update stock
     await Promise.all(items.map(async item => {
       const { product_id, variation_id, quantity, price_at_purchase } = item;
 
@@ -23,7 +23,7 @@ exports.createOrder = async (req, res) => {
         throw new Error("Each order item must have product_id, quantity, and price_at_purchase");
       }
 
-      // 1. Check stock quantity for the selected variation
+      // Checking stock quantity for the selected variation
       const [variationRows] = await pool.query(
         `SELECT variation_id, stock_quantity FROM product_variations WHERE variation_id = ?`,
         [variation_id]
@@ -39,10 +39,10 @@ exports.createOrder = async (req, res) => {
         throw new Error(`Not enough stock for variation ${variation_id}`);
       }
 
-      // 2. Create the order item
+      // Creating the order item
       await OrderItem.create({ order_id: orderId, product_id, variation_id, quantity, price_at_purchase });
 
-      // 3. Decrement stock
+      // 3. Decrementing stock
       const newStock = variation.stock_quantity - quantity;
       await pool.query(
         `UPDATE product_variations SET stock_quantity = ? WHERE variation_id = ?`,
@@ -65,7 +65,7 @@ exports.getOrdersByUser = async (req, res) => {
     }
 
     const userId = req.user.user_id;
-    console.log("🔒 Fetching orders for user_id:", userId);
+    console.log("Fetching orders for user_id:", userId);
 
     const orders = await Order.getByUserId(userId);
 

--- a/backend/src/database/stock_status.sql
+++ b/backend/src/database/stock_status.sql
@@ -1,6 +1,7 @@
 CREATE OR REPLACE VIEW variation_stock_view AS
 SELECT
   pv.product_id,
+  pv.variation_id, 
   pv.serial_number,
   pv.size_id,
   pv.color_id,


### PR DESCRIPTION
### Implemented updating stock after purchase and updated variation_stock_view.

**variation_stock_view**
Added variation_id as a column. Current format looks like:
<img width="715" alt="Screenshot 2025-04-25 at 21 15 43" src="https://github.com/user-attachments/assets/59f6197c-a6c5-49d8-83a7-cd9909c9f95f" />

**updating stock after purchase**
Updated createOrder function to decrease stock for each purchased item. 

(to create a new order) POST http://localhost:5001/api/orders 
JWT Bearer Token with Body as:
```
{
  "delivery_address": "Address 123",
  "total_price": 624.94,
  "items": [
    {
      "product_id": 1,
      "variation_id": 2,
      "quantity": 5,
      "price_at_purchase": 19.99
    },
    {
      "product_id": 4,
      "variation_id": 17,
      "quantity": 8,
      "price_at_purchase": 60.00
    },
    {
      "product_id": 7,
      "variation_id": 31,
      "quantity": 1,
      "price_at_purchase": 44.99
    }
  ]
}

```

<img width="998" alt="Screenshot 2025-04-25 at 21 07 49" src="https://github.com/user-attachments/assets/ecde3879-03d6-4501-b2c7-0f6c18a4ae59" />

Stock view before new order is created (purchased items are indicated):
<img width="736" alt="Screenshot 2025-04-25 at 20 55 13" src="https://github.com/user-attachments/assets/dea94f08-450c-4a11-8789-169dde0d5115" />

Stock view after the order is created:
<img width="715" alt="Screenshot 2025-04-25 at 21 08 31" src="https://github.com/user-attachments/assets/b9ce4919-00b0-426f-9482-6a4f8d74c5ae" />



