### PR TITLE
Removed the add to cart for each product on landing page

### DIFF
--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -144,13 +144,14 @@ const LandingPage = () => {
 
   // 9. Handle adding products to the cart
   // TODO: i'll remove the ability to add products to the cart from landing page
-  const addToCart = (productId) => {
-    const product = products.find((p) => p.product_id === productId);
-    if (product) {
-      setCart((prevCart) => [...prevCart, product]);
-      alert("Product added to your cart!");
-    }
-  };
+  // DOING: trying to remove the add to cart from landing page because users can't add a specific product
+  // const addToCart = (productId) => {
+  //   const product = products.find((p) => p.product_id === productId);
+  //   if (product) {
+  //     setCart((prevCart) => [...prevCart, product]);
+  //     alert("Product added to your cart!");
+  //   }
+  // };
 
   const handleCartClick = (event) => {
     setCartAnchorEl(event.currentTarget);
@@ -309,7 +310,7 @@ const LandingPage = () => {
             <h3 className="product-name">{product.name}</h3>
             <p className="product-price">${product.price}</p>
             <p className="product-popularity">Popularity: {product.popularity_score}</p>
-            <button onClick={() => addToCart(product.product_id)}>Add to Cart</button>
+            {/* <button onClick={() => addToCart(product.product_id)}>Add to Cart</button> */}
             {/* TODO: i will remove the add to cart from landing page for each product because it doesn't make sense */}
           </div>
         ))}


### PR DESCRIPTION
# Overview
Previously, a user could add products to their cart right from the landing page. After some discussion (refer to #80 and #92 ), I decided to remove the ability to add something to cart right from the landing page. The user must go to the specific product page for what they want, choose the variation (like size), and then they'll be able to add something to their cart.

## Comparison
The reasoning is simple, and this PR was made to avoid having too many changes in one PR. The rest will be about changing the `carts` table structure, then another one for changing the endpoints, and one last PR for the cart page itself (refer to #73 ).

### Before
![image](https://github.com/user-attachments/assets/9038a7bb-57e3-43e8-b8e8-5f791c270a94)

### Now
![image](https://github.com/user-attachments/assets/94bccbe2-49b9-451b-871b-d4264f6fd1a1)
