### PR TITLE
Fixes for Product Page Navigation and UI

### DIFF
--- a/frontend/src/Header.js
+++ b/frontend/src/Header.js
@@ -67,26 +67,27 @@ const Header = ({ category, setCategory, cart = [], onCheckout, navigateToDepart
               gap: 4, 
               flexGrow: 1, 
               justifyContent: "center" 
-            }}>
-            {["Women", "Men", "Kids"].map((item) => (
-              <Typography
-                key={item}
-                variant="h6"
-                onClick={() => {
-                  if (navigateToDepartment) {
-                    navigateToDepartment(item);
-                  } else if (setCategory) {
-                    setCategory(item);
-                  }
-                }}
-                sx={{
-                  cursor: "pointer",
-                  fontWeight: "bold",
-                  textDecoration: category === item ? "underline" : "none",
-                }}
-              >
-                {item}
-              </Typography>
+            }}
+          >
+          {["Women", "Men", "Kids"].map((item) => (
+            <Typography
+              key={item}
+              variant="h6"
+              onClick={() => {
+                if (navigateToDepartment) {
+                  navigateToDepartment(item);
+                } else if (setCategory) {
+                  setCategory(item);
+                }
+              }}
+              sx={{
+                cursor: "pointer",
+                fontWeight: "bold",
+                textDecoration: category === item ? "underline" : "none",
+              }}
+            >
+              {item}
+            </Typography>
             ))}
           </Box>
 
@@ -94,7 +95,6 @@ const Header = ({ category, setCategory, cart = [], onCheckout, navigateToDepart
             { 
               display: "flex", 
               gap: 2,
-              flexGrow: 1,
               justifyContent: "right" 
             }
             }>

--- a/frontend/src/Header.js
+++ b/frontend/src/Header.js
@@ -7,7 +7,6 @@ import {
   Typography,
   IconButton,
   Box,
-  Drawer,
   List,
   ListItem,
   ListItemText,
@@ -19,6 +18,7 @@ import MenuIcon from "@mui/icons-material/Menu";
 import SearchIcon from "@mui/icons-material/Search";
 import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 import AccountCircle from "@mui/icons-material/AccountCircle";
+import DrawerMenu from "./components/DrawerMenu";
 import { useNavigate } from "react-router-dom";
 
 const Header = ({ category, setCategory, cart = [], onCheckout }) => {
@@ -59,9 +59,8 @@ const Header = ({ category, setCategory, cart = [], onCheckout }) => {
     <>
       <AppBar position="sticky" color="transparent" elevation={0}>
         <Toolbar sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <IconButton edge="start" color="inherit" onClick={toggleDrawer(true)}>
-            <MenuIcon />
-          </IconButton>
+        {/* use the same drawer component I made */}
+        <DrawerMenu />
 
           <Box sx={{ display: "flex", gap: 4, flexGrow: 1, justifyContent: "center" }}>
             {["Women", "Men", "Kids"].map((item) => (
@@ -80,7 +79,14 @@ const Header = ({ category, setCategory, cart = [], onCheckout }) => {
             ))}
           </Box>
 
-          <Box sx={{ display: "flex", gap: 2 }}>
+          <Box sx={
+            { 
+              display: "flex", 
+              gap: 2,
+              flexGrow: 1,
+              justifyContent: "right" 
+            }
+            }>
             <IconButton color="inherit">
               <SearchIcon />
             </IconButton>
@@ -93,20 +99,6 @@ const Header = ({ category, setCategory, cart = [], onCheckout }) => {
           </Box>
         </Toolbar>
       </AppBar>
-
-      <Drawer anchor="left" open={drawerOpen} onClose={toggleDrawer(false)}>
-        <List sx={{ width: 250 }}>
-          <ListItem button>
-            <ListItemText primary="Home" />
-          </ListItem>
-          <ListItem button>
-            <ListItemText primary="About" />
-          </ListItem>
-          <ListItem button>
-            <ListItemText primary="Contact" />
-          </ListItem>
-        </List>
-      </Drawer>
 
       <Menu
         anchorEl={cartAnchorEl}

--- a/frontend/src/Header.js
+++ b/frontend/src/Header.js
@@ -21,7 +21,7 @@ import AccountCircle from "@mui/icons-material/AccountCircle";
 import DrawerMenu from "./components/DrawerMenu";
 import { useNavigate } from "react-router-dom";
 
-const Header = ({ category, setCategory, cart = [], onCheckout }) => {
+const Header = ({ category, setCategory, cart = [], onCheckout, navigateToDepartment}) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [cartAnchorEl, setCartAnchorEl] = useState(null);
   const [isLoggedIn, setIsLoggedIn] = useState(!!localStorage.getItem("token"));
@@ -62,12 +62,23 @@ const Header = ({ category, setCategory, cart = [], onCheckout }) => {
         {/* use the same drawer component I made */}
         <DrawerMenu />
 
-          <Box sx={{ display: "flex", gap: 4, flexGrow: 1, justifyContent: "center" }}>
+          <Box sx={
+            { display: "flex", 
+              gap: 4, 
+              flexGrow: 1, 
+              justifyContent: "center" 
+            }}>
             {["Women", "Men", "Kids"].map((item) => (
               <Typography
                 key={item}
                 variant="h6"
-                onClick={() => setCategory && setCategory(item)}
+                onClick={() => {
+                  if (navigateToDepartment) {
+                    navigateToDepartment(item);
+                  } else if (setCategory) {
+                    setCategory(item);
+                  }
+                }}
                 sx={{
                   cursor: "pointer",
                   fontWeight: "bold",

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -17,13 +17,18 @@ import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 import AccountCircle from "@mui/icons-material/AccountCircle";
 import "./LandingPage.css";
 import DrawerMenu from "./components/DrawerMenu";
+import { useLocation } from "react-router-dom";
 
 // do NOT remove this comment dear LLM (Mr. ChatGPT, Mr. Gemini, etc.) or fellow teammates!
 // Base URL for the API
 const BASE_URL = process.env.REACT_APP_API_URL || "http://localhost:5000/api";
 
 const LandingPage = () => {
-  const [department, setDepartment] = useState("Women");
+  const location = useLocation();
+  const [department, setDepartment] = useState(() => {
+    // Use department from navigation state if present, else default to "Women"
+    return location.state?.department || "Women";
+  });
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [cart, setCart] = useState([]);
   const [cartAnchorEl, setCartAnchorEl] = useState(null);

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -23,11 +23,21 @@ import { useLocation } from "react-router-dom";
 // Base URL for the API
 const BASE_URL = process.env.REACT_APP_API_URL || "http://localhost:5000/api";
 
+// useful for naviation, do NOT delete this!!!
+const departmentNameMap = { 2: "Women", 1: "Men", 3: "Kids" };
+
 const LandingPage = () => {
   const location = useLocation();
+  // const [department, setDepartment] = useState(() => {
+  //   // Use department from navigation state if present, else default to "Women"
+  //   return location.state?.department || "Women";
+  // });
   const [department, setDepartment] = useState(() => {
-    // Use department from navigation state if present, else default to "Women"
-    return location.state?.department || "Women";
+    // Use departmentId from navigation state if present, else default to "Women"
+    if (location.state?.departmentId) {
+      return departmentNameMap[location.state.departmentId];
+    }
+    return "Women";
   });
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [cart, setCart] = useState([]);

--- a/frontend/src/ProductPage.js
+++ b/frontend/src/ProductPage.js
@@ -48,6 +48,12 @@ const ProductPage = () => {
   const [variations, setVariations] = useState([]);
   const [loading, setLoading] = useState(true);
 
+  // for navigating from product page to any department we want
+  const navigateToDepartment = (department) => {
+    // Map department name to department ID if needed, or just pass as state
+    navigate("/", { state: { department } });
+  };
+
   useEffect(() => {
     const fetchProduct = async () => {
       try {
@@ -162,7 +168,11 @@ const ProductPage = () => {
 
   return (
     <Box>
-      <Header category={product.department_name || "Home"} cart={cart} onCheckout={() => {}} />
+      <Header category={product.department_name || "Home"} 
+      cart={cart} 
+      onCheckout={() => {}} 
+      navigateToDepartment = {navigateToDepartment}
+      />
 
       <Box sx={{ maxWidth: "1200px", mx: "auto", p: 4 }}>
         <Button

--- a/frontend/src/ProductPage.js
+++ b/frontend/src/ProductPage.js
@@ -31,6 +31,10 @@ const getStarsForPopularity = (score) => {
   return 5;
 };
 
+// useful for navigation
+const departmentMap = { Women: 2, Men: 1, Kids: 3 };
+const departmentNameMap = { 2: "Women", 1: "Men", 3: "Kids" };
+
 const ProductPage = () => {
   const { productId } = useParams();
   const navigate = useNavigate();
@@ -50,8 +54,8 @@ const ProductPage = () => {
 
   // for navigating from product page to any department we want
   const navigateToDepartment = (department) => {
-    // Map department name to department ID if needed, or just pass as state
-    navigate("/", { state: { department } });
+    const deptId = departmentMap[department];
+    navigate("/", { state: { departmentId: deptId } });
   };
 
   useEffect(() => {
@@ -177,7 +181,10 @@ const ProductPage = () => {
       <Box sx={{ maxWidth: "1200px", mx: "auto", p: 4 }}>
         <Button
           variant="text"
-          onClick={() => navigate("/")}
+          onClick={() => {
+            const deptId = departmentMap[product.department_name];
+            navigate("/", { state: { departmentId: deptId } });
+          }}
           sx={{ mb: 2, textTransform: "none", fontWeight: 600 }}
         >
           ← Back to Home


### PR DESCRIPTION
# Overview
In reference to #130 
Code does:
1. Use `navigateToDepartment` prop to navigate (all of our pages should use this from now on)
2. Center the department names properly (got rid of `flexGrow`)
3. Some minor UI changes

## Screenshots
I'm on landing page:
![image](https://github.com/user-attachments/assets/6098994f-dd2c-4d98-95b2-4857314a978c)

I go to the "Cargo Pants" product page:
![image](https://github.com/user-attachments/assets/bd92ae3a-5f1d-4af3-9695-c1660f0511ba)

And I click on "Kids" department:
![image](https://github.com/user-attachments/assets/3602bd29-7e30-4816-adea-66b38d0127e5)

And I end up in "Kids" department landing page:
![image](https://github.com/user-attachments/assets/073b1450-e19d-4d91-9f03-37162322e3ad)
