### PR TITLE
Fix for Product Page's Add to Cart Weird Behavior

### DIFF
--- a/frontend/src/ProductPage.js
+++ b/frontend/src/ProductPage.js
@@ -44,7 +44,6 @@ const ProductPage = () => {
   const [reviewText, setReviewText] = useState("");
   const [reviewRating, setReviewRating] = useState(0);
   const [selectedVariation, setSelectedVariation] = useState("");
-  // const [quantity, setQuantity] = useState(1);
 
   // allow empty string
   const [quantity, setQuantity] = useState("");
@@ -131,6 +130,12 @@ const ProductPage = () => {
   };
 
   const handleAddToCart = async () => {
+    // sanity check before sending request to backend
+    if (!quantity || isNaN(Number(quantity)) || Number(quantity) < 1) {
+      setQuantityError("You have to choose a valid quantity");
+      return;
+    }
+
     try {
       const headers = {};
       const token = localStorage.getItem('token');
@@ -144,7 +149,7 @@ const ProductPage = () => {
       await axios.post(`${BASE_URL}/cart/add`, {
         product_id: productId,
         variation_id: selectedVariation,
-        quantity,
+        quantity: Number(quantity),
       }, { headers });
 
       alert('Added to cart successfully!');
@@ -214,6 +219,8 @@ const ProductPage = () => {
           <Box sx={{ flex: 1 }}>
             <Typography variant="h5" fontWeight="bold">{product.name}</Typography>
             <Typography variant="h6" color="primary" sx={{ mt: 1 }}>${product.price}</Typography>
+            
+            {/* to show the popularity of product via stars */}
             <Box sx={{ mt: 1, display: "flex", alignItems: "center", gap: 1 }}>
             <Rating
               value={getStarsForPopularity(product.popularity_score)}
@@ -222,6 +229,8 @@ const ProductPage = () => {
             />
               <Typography variant="body2">({reviews.length} reviews)</Typography>
             </Box>
+
+            {/* to show the material */}
             <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
               Material: <strong>{product.material || "N/A"}</strong>
             </Typography>
@@ -230,10 +239,15 @@ const ProductPage = () => {
             {/* Select Size */}
             <FormControl fullWidth sx={{ mb: 2 }}>
               <InputLabel>Select Size</InputLabel>
+ 
+              {/* set the default quantity if variation is chosen */}
               <Select
                 value={selectedVariation}
                 label="Select Size"
-                onChange={(e) => setSelectedVariation(e.target.value)}
+                onChange={(e) => {
+                  setSelectedVariation(e.target.value);
+                  if (!quantity) setQuantity("1");
+                }}
               >
                 {variations.map((v) => (
                   <MenuItem key={v.variation_id} value={v.variation_id} disabled={v.stock_quantity === 0}>
@@ -244,15 +258,6 @@ const ProductPage = () => {
             </FormControl>
 
             {/* Quantity */}
-            {/* <TextField
-              type="number"
-              label="Quantity"
-              fullWidth
-              value={quantity}
-              onChange={(e) => setQuantity(Math.max(1, parseInt(e.target.value) || 1))}
-              sx={{ mb: 2 }}
-            /> */}
-
             <TextField
               type="number"
               label="Quantity"

--- a/frontend/src/ProductPage.js
+++ b/frontend/src/ProductPage.js
@@ -44,7 +44,13 @@ const ProductPage = () => {
   const [reviewText, setReviewText] = useState("");
   const [reviewRating, setReviewRating] = useState(0);
   const [selectedVariation, setSelectedVariation] = useState("");
-  const [quantity, setQuantity] = useState(1);
+  // const [quantity, setQuantity] = useState(1);
+
+  // allow empty string
+  const [quantity, setQuantity] = useState("");
+
+  // for error message
+  const [quantityError, setQuantityError] = useState("");
 
   const [cart] = useState([]);
   const [product, setProduct] = useState(null);
@@ -238,13 +244,30 @@ const ProductPage = () => {
             </FormControl>
 
             {/* Quantity */}
-            <TextField
+            {/* <TextField
               type="number"
               label="Quantity"
               fullWidth
               value={quantity}
               onChange={(e) => setQuantity(Math.max(1, parseInt(e.target.value) || 1))}
               sx={{ mb: 2 }}
+            /> */}
+
+            <TextField
+              type="number"
+              label="Quantity"
+              fullWidth
+              value={quantity}
+              onChange={(e) => {
+                const val = e.target.value;
+                // Allow empty string or positive integers only
+                if (val === "" || (/^\d+$/.test(val) && Number(val) > 0)) {
+                  setQuantity(val);
+                  setQuantityError(""); // clear error on change
+                }
+              }}
+              error={!!quantityError}
+              helperText={quantityError}
             />
 
             {/* Add to Cart */}


### PR DESCRIPTION
# Overview
Refer to #139 
Basically fixed the quantity box acting weird.

## Screenshots
Go to product.
![image](https://github.com/user-attachments/assets/c654a71a-fae5-451f-980d-0f28077b4454)

You can choose a size and by default it assigns 1 to the quantity count.
![image](https://github.com/user-attachments/assets/a153c9d6-1342-4395-bcc0-e5822462ac01)

You can now delete that number if you don't want 1, but perhaps 5 or some other single digit number (that doesn't start with 1):
![image](https://github.com/user-attachments/assets/9a7a2736-9467-4f2d-a8db-5bd9b1c3a9ac)

And it throws errors if you leave it empty:
![image](https://github.com/user-attachments/assets/2137c13c-2a51-46e0-b9d6-86a5b8c447d3)

Also, you can't enter zero or negative numbers (by typing dash) because it automatically rejects those inputs and resets the field, which is pretty nice.