### PR TITLE
PR for Cart Table's Schema Update about Unique Keys

### DIFF
--- a/backend/src/database/carts_schema.sql
+++ b/backend/src/database/carts_schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS carts (
   product_id BIGINT UNSIGNED NOT NULL,
   variation_id BIGINT UNSIGNED NOT NULL, -- can't add a product without specifying a variation
   quantity INT UNSIGNED NOT NULL,
-  UNIQUE KEY unique_cart_item (user_id, session_id, product_id),
+  UNIQUE KEY unique_cart_item (user_id, session_id, product_id, variation_id), -- included variation ID to avoid bug 157
   FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
   FOREIGN KEY (product_id) REFERENCES products(product_id) ON DELETE CASCADE,
   FOREIGN KEY (variation_id) REFERENCES product_variations(variation_id) ON DELETE CASCADE


### PR DESCRIPTION
# Overview
This PR addresses the bug #157 .

## Info
I change the code in `backend/src/models/cart.js`. The modified line is:

```sql
UNIQUE KEY unique_cart_item (user_id, session_id, product_id, variation_id), -- included variation ID to avoid bug 157
```

Note that you have to drop the current `carts` table from MySQL and do a new table creation for it to make the changes work.

```sql
mysql> DROP TABLE IF EXISTS carts;
mysql> SOURCE /path_to_your_project/cs308-project/backend/src/database/carts_schema.sql;
```

cc. @zeynepyaman , @ArifSari-maker 

## Screenshots
Go to landing page and then choose a product that has multiple variations in stock (like "Sporty Sandals").
![image](https://github.com/user-attachments/assets/2ed807c5-f45b-4b53-818b-6304f8204d2c)

Let's choose a singular item of Sporty Sandals with size **25-27**.
![image](https://github.com/user-attachments/assets/6b4ef2b2-854d-4780-8227-b3ec2d7a8b90)

And let's choose 2 items of the same product but with variation of size **28-30**. 
![image](https://github.com/user-attachments/assets/f3fd9e10-24bf-47f0-98dc-cfac40a5503f)

> I chose 2 so that we'd see the difference. We have to probably write the categorical name of the variation ID to help the user understand better.

Let's check the DB before attempting to log in to see if the products are correctly inserted into `carts` table for an anonymous visitor (their `user_id = NULL`):
![image](https://github.com/user-attachments/assets/9ae8fd85-b5a4-48f5-813e-49d7f8933ac9)

Then I log in as `newuser@example.com` with the password `password123`, and see the profile page:
![image](https://github.com/user-attachments/assets/c5343587-ea94-49b9-9637-a619c1bfc76c)

At the same time, we can verify that the DB is updated accordingly without an error:
![image](https://github.com/user-attachments/assets/ba859f09-2056-4f96-a970-0a53bbc109c9)

> The error we fixed used to look like this:
```
Login error: Error: Duplicate entry '2-session_1746095408511_mvhj1j51jjn_65855e08-4dc3-4c1f-8d58-f6da' for key 'carts.unique_cart_item'
    at PromisePool.query (/.../cs308-project/backend/node_modules/mysql2/lib/promise/pool.js:36:22)
    at Object.updateCartUserId (/.../cs308-project/backend/src/models/cart.js:179:14)
    at login (/.../cs308-project/backend/src/controllers/authController.js:103:20) {
  code: 'ER_DUP_ENTRY',
  errno: 1062,
  sql: "UPDATE carts SET user_id = 2 WHERE session_id = 'session_1746095408511_mvhj1j51jjn_65855e08-4dc3-4c1f-8d58-f6dafc9a7e9a' AND user_id IS NULL",
  sqlState: '23000',
  sqlMessage: "Duplicate entry '2-session_1746095408511_mvhj1j51jjn_65855e08-4dc3-4c1f-8d58-f6da' for key 'carts.unique_cart_item'"
}
```

Since it was a successful update in the backend for `backend/src/models/cart.js`, it can also be seen visually on the website as:
![image](https://github.com/user-attachments/assets/85ee16cf-a926-4c0e-98de-dda97a743902)

So everything is fine now.
