### PR TITLE
PR for Mini Cart Visual Improvements

### DIFF
--- a/backend/src/models/cart.js
+++ b/backend/src/models/cart.js
@@ -7,13 +7,26 @@ const Cart = {
     let rows;
     if (user_id) {
       // so person is authenticated (logged in or signed up)
+      // [rows] = await db.query(
+      //   `SELECT c.product_id, c.variation_id, c.quantity,
+      //       p.name, p.price,
+      //       pv.size_id, pv.color_id
+      //     FROM carts c
+      //     JOIN products p ON c.product_id = p.product_id
+      //     JOIN product_variations pv ON c.variation_id = pv.variation_id
+      //     WHERE c.user_id = ?`,
+      //   [user_id]
+      // );
       [rows] = await db.query(
         `SELECT c.product_id, c.variation_id, c.quantity,
             p.name, p.price,
-            pv.size_id, pv.color_id
+            pv.size_id, s.size_name,
+            pv.color_id, co.color_name
           FROM carts c
           JOIN products p ON c.product_id = p.product_id
           JOIN product_variations pv ON c.variation_id = pv.variation_id
+          JOIN sizes s ON pv.size_id = s.size_id
+          JOIN colors co ON pv.color_id = co.color_id
           WHERE c.user_id = ?`,
         [user_id]
       );
@@ -22,10 +35,13 @@ const Cart = {
       [rows] = await db.query(
         `SELECT c.product_id, c.variation_id, c.quantity,
             p.name, p.price,
-            pv.size_id, pv.color_id
+            pv.size_id, s.size_name,
+            pv.color_id, co.color_name
           FROM carts c
           JOIN products p ON c.product_id = p.product_id
           JOIN product_variations pv ON c.variation_id = pv.variation_id
+          JOIN sizes s ON pv.size_id = s.size_id
+          JOIN colors co ON pv.color_id = co.color_id
           WHERE c.session_id = ?`,
         [session_id]
       );

--- a/backend/src/models/cart.js
+++ b/backend/src/models/cart.js
@@ -7,16 +7,6 @@ const Cart = {
     let rows;
     if (user_id) {
       // so person is authenticated (logged in or signed up)
-      // [rows] = await db.query(
-      //   `SELECT c.product_id, c.variation_id, c.quantity,
-      //       p.name, p.price,
-      //       pv.size_id, pv.color_id
-      //     FROM carts c
-      //     JOIN products p ON c.product_id = p.product_id
-      //     JOIN product_variations pv ON c.variation_id = pv.variation_id
-      //     WHERE c.user_id = ?`,
-      //   [user_id]
-      // );
       [rows] = await db.query(
         `SELECT c.product_id, c.variation_id, c.quantity,
             p.name, p.price,

--- a/backend/src/models/cart.js
+++ b/backend/src/models/cart.js
@@ -20,8 +20,8 @@ const Cart = {
       [rows] = await db.query(
         `SELECT c.product_id, c.variation_id, c.quantity,
             p.name, p.price,
-            pv.size_id, s.size_name,
-            pv.color_id, co.color_name
+            pv.size_id, s.name AS size_name,
+            pv.color_id, co.name AS color_name
           FROM carts c
           JOIN products p ON c.product_id = p.product_id
           JOIN product_variations pv ON c.variation_id = pv.variation_id
@@ -35,8 +35,8 @@ const Cart = {
       [rows] = await db.query(
         `SELECT c.product_id, c.variation_id, c.quantity,
             p.name, p.price,
-            pv.size_id, s.size_name,
-            pv.color_id, co.color_name
+            pv.size_id, s.name AS size_name,
+            pv.color_id, co.name AS color_name
           FROM carts c
           JOIN products p ON c.product_id = p.product_id
           JOIN product_variations pv ON c.variation_id = pv.variation_id

--- a/frontend/src/components/MiniCart.js
+++ b/frontend/src/components/MiniCart.js
@@ -43,7 +43,6 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
 
   useEffect(() => {
     if (open) fetchCart();
-    // eslint-disable-next-line
   }, [open]);
 
   // Handlers for plus, minus, remove
@@ -100,8 +99,8 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
       transformOrigin={{ vertical: "top", horizontal: "right" }}
       PaperProps={{
         sx: {
-          width: 340,           // fixed width
-          maxHeight: 420,       // max height for scroll
+          width: 340, // fix the width
+          maxHeight: 420, // you can scroll if it's more than max height
           overflowY: "auto",
           p: 0.5,
         },
@@ -126,7 +125,12 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                 minHeight: 70,
               }}
             >
-              <Box sx={{ display: "flex", alignItems: "center", width: "100%" }}>
+              <Box sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  width: "100%"
+                }}
+              >
                 <Box sx={{ flex: 1 }}>
                   <Typography variant="body1" fontWeight="bold">
                     {item.name}
@@ -142,7 +146,6 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                 <Box
                   sx={{
                     display: "flex",
-                    // flexDirection: "column",
                     alignItems: "center",
                     ml: 2,
                     gap: 0.5,
@@ -155,7 +158,6 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                     disabled={actionLoading === idx || item.quantity <= 1}
                     title="Decrease"
                   >
-                    {/* ➖ */}
                     <RemoveIcon sx={{ color: "#222" }} />
                   </IconButton>
                   <IconButton
@@ -164,7 +166,6 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                     disabled={actionLoading === idx}
                     title="Increase"
                   >
-                    {/* ➕ */}
                     <AddIcon sx={{ color: "#222" }} />
                   </IconButton>
                   <IconButton
@@ -173,7 +174,6 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                     disabled={actionLoading === idx}
                     title="Remove"
                   >
-                    {/* 🗑️ */}
                     <DeleteIcon sx={{ color: "#222" }} />
                   </IconButton>
                   </Box>

--- a/frontend/src/components/MiniCart.js
+++ b/frontend/src/components/MiniCart.js
@@ -109,10 +109,14 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
               <Box sx={{ display: "flex", alignItems: "center", width: "100%" }}>
                 <Box sx={{ flex: 1 }}>
                   <Typography variant="body1" fontWeight="bold">
-                    {item.name} - {item.size_name} / {item.color_name}
+                    {item.name}
                     </Typography>
+                    {/* we can also show the color as `{item.color_name}` but not needed */}
                   <Typography variant="body2">
                     ${item.price} (x{item.quantity})
+                  </Typography>
+                  <Typography variant="body2">
+                    Size: {item.size_name}
                   </Typography>
                 </Box>
                 <Box sx={{ display: "flex", alignItems: "center", ml: 1 }}>

--- a/frontend/src/components/MiniCart.js
+++ b/frontend/src/components/MiniCart.js
@@ -108,7 +108,9 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
             <MenuItem key={idx} sx={{ whiteSpace: "normal", alignItems: "flex-start" }}>
               <Box sx={{ display: "flex", alignItems: "center", width: "100%" }}>
                 <Box sx={{ flex: 1 }}>
-                  <Typography variant="body1" fontWeight="bold">{item.name}</Typography>
+                  <Typography variant="body1" fontWeight="bold">
+                    {item.name} - {item.size_name} / {item.color_name}
+                    </Typography>
                   <Typography variant="body2">
                     ${item.price} (x{item.quantity})
                   </Typography>

--- a/frontend/src/components/MiniCart.js
+++ b/frontend/src/components/MiniCart.js
@@ -11,6 +11,9 @@ import {
 import { getOrCreateSessionId } from "../utils/sessionStorage";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import RemoveIcon from "@mui/icons-material/Remove";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
 
 const API_URL = process.env.REACT_APP_API_URL || "http://localhost:5000/api";
 
@@ -152,7 +155,8 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                     disabled={actionLoading === idx || item.quantity <= 1}
                     title="Decrease"
                   >
-                    ➖
+                    {/* ➖ */}
+                    <RemoveIcon sx={{ color: "#222" }} />
                   </IconButton>
                   <IconButton
                     size="small"
@@ -160,7 +164,8 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                     disabled={actionLoading === idx}
                     title="Increase"
                   >
-                    ➕
+                    {/* ➕ */}
+                    <AddIcon sx={{ color: "#222" }} />
                   </IconButton>
                   <IconButton
                     size="small"
@@ -168,7 +173,8 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                     disabled={actionLoading === idx}
                     title="Remove"
                   >
-                    🗑️
+                    {/* 🗑️ */}
+                    <DeleteIcon sx={{ color: "#222" }} />
                   </IconButton>
                   </Box>
                 </Box>

--- a/frontend/src/components/MiniCart.js
+++ b/frontend/src/components/MiniCart.js
@@ -95,6 +95,14 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
       onClose={onClose}
       anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
       transformOrigin={{ vertical: "top", horizontal: "right" }}
+      PaperProps={{
+        sx: {
+          width: 340,           // fixed width
+          maxHeight: 420,       // max height for scroll
+          overflowY: "auto",
+          p: 0.5,
+        },
+      }}
     >
       {loading ? (
         <Box sx={{ p: 2, display: "flex", alignItems: "center" }}>
@@ -105,7 +113,16 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
       ) : (
         <>
           {cart.items.map((item, idx) => (
-            <MenuItem key={idx} sx={{ whiteSpace: "normal", alignItems: "flex-start" }}>
+            <MenuItem
+              key={idx}
+              sx={{
+                whiteSpace: "normal",
+                alignItems: "flex-start",
+                py: 1,
+                px: 1.5,
+                minHeight: 70,
+              }}
+            >
               <Box sx={{ display: "flex", alignItems: "center", width: "100%" }}>
                 <Box sx={{ flex: 1 }}>
                   <Typography variant="body1" fontWeight="bold">
@@ -119,7 +136,16 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                     Size: {item.size_name}
                   </Typography>
                 </Box>
-                <Box sx={{ display: "flex", alignItems: "center", ml: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    // flexDirection: "column",
+                    alignItems: "center",
+                    ml: 2,
+                    gap: 0.5,
+                  }}
+                >
+                <Box sx={{ display: "flex", alignItems: "center" }}>
                   <IconButton
                     size="small"
                     onClick={() => handleUpdateQuantity(item, item.quantity - 1, idx)}
@@ -144,6 +170,7 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
                   >
                     🗑️
                   </IconButton>
+                  </Box>
                 </Box>
               </Box>
             </MenuItem>


### PR DESCRIPTION
# Overview
This is about #159 and also more quality of life changes for the mini cart.

cc. @ArifSari-maker , @zeynepyaman 

## Info
1. The mini cart now has a uniform size.
2. If the content of the mini cart go over a threshold, it'll become scroll-able, instead of infinitely long.
3. The icons are changed from emojis to Material UI's standard icons as:
```js
import RemoveIcon from "@mui/icons-material/Remove";
import AddIcon from "@mui/icons-material/Add";
import DeleteIcon from "@mui/icons-material/Delete";
```
4. The cart items now show the size variation of the product too.
5. We can also print the color but I commented it out as below in `frontend/src/components/MiniCart.js`:
```js
<Box sx={{ flex: 1 }}>
  <Typography variant="body1" fontWeight="bold">
    {item.name}
    </Typography>
    {/* we can also show the color as `{item.color_name}` but not needed */}
  <Typography variant="body2">
    ${item.price} (x{item.quantity})
  </Typography>
  <Typography variant="body2">
    Size: {item.size_name}
  </Typography>
</Box>
```
6. The updated code for the backend + DB can be found in `backend/src/models/cart.js` as:
```js
getCart: async (user_id, session_id) => {
  let rows;
  if (user_id) {
    // so person is authenticated (logged in or signed up)
    [rows] = await db.query(
      `SELECT c.product_id, c.variation_id, c.quantity,
          p.name, p.price,
          pv.size_id, s.name AS size_name,
          pv.color_id, co.name AS color_name
        FROM carts c
        JOIN products p ON c.product_id = p.product_id
        JOIN product_variations pv ON c.variation_id = pv.variation_id
        JOIN sizes s ON pv.size_id = s.size_id
        JOIN colors co ON pv.color_id = co.color_id
        WHERE c.user_id = ?`,
      [user_id]
    );
  } else {
    // anon visitor, so use their session ID (similar query)
```
7. Now, all of our icons look uniform in their design and we don't have random emojis.

## Screenshots
What the new icons now look like:
![image](https://github.com/user-attachments/assets/94a03040-6cf0-4b5f-8fb0-a9494c25e020)

And you can scroll down in the mini cart if it's too long (instead rendering a very long mini cart):
![image](https://github.com/user-attachments/assets/d4d39000-d244-4407-b7be-bae8ca4469df)
