### PR TITLE
Ratings not showing directly when a review is submitted is fixed

### DIFF
--- a/backend/src/models/reviews.js
+++ b/backend/src/models/reviews.js
@@ -14,9 +14,7 @@ const Review = {
         u.username
       FROM product_reviews pr
       JOIN users u ON pr.user_id = u.user_id
-      WHERE 1=1
-        AND pr.product_id = ?
-        AND pr.comment_approval = 'approved'
+      WHERE pr.product_id = ?
       ORDER BY pr.created_at DESC;
     `;
     const [rows] = await pool.query(query, [productId]);

--- a/frontend/src/ProductPage.js
+++ b/frontend/src/ProductPage.js
@@ -312,16 +312,30 @@ const ProductPage = () => {
         {/* Reviews Section */}
         <Box mt={6}>
           <Typography variant="h6" gutterBottom>Customer Reviews</Typography>
-          {reviews.length === 0 ? (
+          {reviews.filter(
+            (review) =>
+              review.rating !== null || review.comment_approval === "approved"
+          ).length === 0 ? (
             <Typography variant="body2" color="text.secondary">No reviews yet.</Typography>
           ) : (
-            reviews.map((review) => (
-              <Box key={review.review_id} sx={{ mb: 2 }}>
-                <Typography variant="subtitle2">{review.username}</Typography>
-                <Rating value={review.rating} readOnly size="small" />
-                <Typography variant="body2">{review.comment}</Typography>
-              </Box>
-            ))
+            reviews
+              .filter(
+                (review) =>
+                  review.rating !== null || review.comment_approval === "approved"
+              )
+              .map((review) => (
+                <Box key={review.review_id} sx={{ mb: 2 }}>
+                  {(review.rating !== null || review.comment_approval === "approved") && (
+                    <Typography variant="subtitle2">{review.username}</Typography>
+                  )}
+                  {review.rating !== null && (
+                    <Rating value={review.rating} readOnly size="small" />
+                  )}
+                  {review.comment_approval === "approved" && review.comment && (
+                    <Typography variant="body2">{review.comment}</Typography>
+                  )}
+                </Box>
+              ))
           )}
         </Box>
 


### PR DESCRIPTION
Ratings not showing directly when a review is submitted is fixed. Now, getReviewsByProductId gets all reviews and we are doing the review approval status filtering directly on ProductPage.js.

### **1. Review contains RATING AND COMMENT**
Submitting review:
<img width="1440" alt="Screenshot 2025-05-03 at 20 26 55" src="https://github.com/user-attachments/assets/64147ad9-6578-4b26-b3c1-736847a6689a" />

Immediately after submission (As you can see, the rating is posted on the productpage)
<img width="1440" alt="Screenshot 2025-05-03 at 20 27 04" src="https://github.com/user-attachments/assets/c11cf4b5-b4c1-45a8-a92e-6857df3f4d1d" />

Then the comment is approved:
<img width="712" alt="Screenshot 2025-05-03 at 20 27 43" src="https://github.com/user-attachments/assets/69f7e4b2-1e1c-4229-83c3-2d3bbe8d5aa5" />

And after refreshing the product page it can be seen that both the rating and the comment is displayed:
<img width="1440" alt="Screenshot 2025-05-03 at 20 28 02" src="https://github.com/user-attachments/assets/5a951998-ab0f-499c-bbab-e9c6e8bb9f20" />

### **2. Review contains ONLY RATING AND NO COMMENT**
Submitting a rating only review:
<img width="1440" alt="Screenshot 2025-05-03 at 20 29 41" src="https://github.com/user-attachments/assets/2d92a45d-dc62-4d06-9b25-29be57ccc3fc" />

After reloading the page after submission: 
<img width="1440" alt="Screenshot 2025-05-03 at 20 29 52" src="https://github.com/user-attachments/assets/fb92b5e0-ed48-4eec-99c0-cfa5dea8c551" />

### **3. Review contains ONLY COMMENT AND NO RATING**
Submitting the review:
<img width="1440" alt="Screenshot 2025-05-03 at 20 31 05" src="https://github.com/user-attachments/assets/cf5e08a2-9747-4d31-b0e5-ed2f1e8d4dd5" />

After reloading the page after submission. There is no reviews shown for the user:
<img width="1440" alt="Screenshot 2025-05-03 at 20 31 12" src="https://github.com/user-attachments/assets/6f712c26-db7a-46c8-a9f7-c6b18d27854e" />

Approving the review:
<img width="643" alt="Screenshot 2025-05-03 at 20 31 40" src="https://github.com/user-attachments/assets/d36d079e-44d0-452d-92e8-10184f7a91c1" />

After reviews is approved it's shown in the product page:
<img width="1440" alt="Screenshot 2025-05-03 at 20 31 53" src="https://github.com/user-attachments/assets/88418e4c-0939-4242-83bc-2e515970a7f9" />
