### PR TITLE
Updated Profile Page with Cart Items and UI Updates

### DIFF
--- a/backend/src/models/cart.js
+++ b/backend/src/models/cart.js
@@ -9,7 +9,7 @@ const Cart = {
       // so person is authenticated (logged in or signed up)
       [rows] = await db.query(
         `SELECT c.product_id, c.variation_id, c.quantity,
-            p.name, p.price,
+            p.name, p.price, p.image_url,
             pv.size_id, s.name AS size_name,
             pv.color_id, co.name AS color_name
           FROM carts c
@@ -24,7 +24,7 @@ const Cart = {
       // anon visitor, so use their session ID
       [rows] = await db.query(
         `SELECT c.product_id, c.variation_id, c.quantity,
-            p.name, p.price,
+            p.name, p.price, p.image_url,
             pv.size_id, s.name AS size_name,
             pv.color_id, co.name AS color_name
           FROM carts c

--- a/frontend/src/ProfilePage.js
+++ b/frontend/src/ProfilePage.js
@@ -4,6 +4,7 @@ import { List, ListItem, ListItemText, Button, Typography, Collapse } from '@mui
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 
 const API_URL = process.env.REACT_APP_API_URL;
 
@@ -153,6 +154,7 @@ const ProfilePage = () => {
             onClick={handleToggleOrders}
             style={{ cursor: 'pointer', textDecoration: openOrders ? 'underline' : 'none' }}
           >
+            <ReceiptLongIcon fontSize="small" style={{ marginRight: 4 }} />
             Orders
           </Typography>
           {/* Cart Section */}

--- a/frontend/src/ProfilePage.js
+++ b/frontend/src/ProfilePage.js
@@ -240,6 +240,13 @@ const ProfilePage = () => {
                           </>
                         }
                       />
+                      {/* Show product image thumbnail */}
+                      <img
+                        src={`${process.env.PUBLIC_URL}/assets/images/${item.image_url}.jpg`}
+                        alt={item.name}
+                        onError={e => e.target.src = `${process.env.PUBLIC_URL}/assets/images/placeholder.jpg`}
+                        style={{ width: 89, height: 115, objectFit: "cover", marginRight: 12, borderRadius: 4 }}
+                      />
                     </ListItem>
                   </div>
                 ))}

--- a/frontend/src/ProfilePage.js
+++ b/frontend/src/ProfilePage.js
@@ -3,6 +3,7 @@ import AccountCircle from "@mui/icons-material/AccountCircle";
 import { List, ListItem, ListItemText, Button, Typography, Collapse } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 
 const API_URL = process.env.REACT_APP_API_URL;
 
@@ -10,12 +11,19 @@ const ProfilePage = () => {
   const navigate = useNavigate();
 
   const [profile, setProfile] = useState(null);
+
+  // for showing the orders
   const [orders, setOrders] = useState([]);
   const [error, setError] = useState(null);
   const [openOrders, setOpenOrders] = useState(false);
 
+  // for showing the cart items
+  const [cart, setCart] = useState({ items: [], total_price: 0 });
+  const [openCart, setOpenCart] = useState(false);
+
   useEffect(() => {
     fetchUserProfile();
+    fetchCart();
   }, []);
 
   const fetchUserProfile = async () => {
@@ -63,6 +71,7 @@ const ProfilePage = () => {
     navigate("/");
   };
 
+  // for showing the orders
   const handleToggleOrders = () => {
     setOpenOrders(!openOrders);
   };
@@ -70,6 +79,23 @@ const ProfilePage = () => {
   const handleOrderClick = (orderId) => {
     // Navigate to the Order Status page, passing the orderId in the URL
     navigate(`/order/${orderId}`);
+  };
+
+  // for showing the cart items
+  const fetchCart = async () => {
+    try {
+      const token = localStorage.getItem("token");
+      const headers = { "Authorization": `Bearer ${token}` };
+      const res = await axios.get(`${API_URL}/cart`, { headers });
+      setCart(res.data);
+    } catch (err) {
+      setCart({ items: [], total_price: 0 });
+    }
+  };
+
+  const handleToggleCart = () => {
+    setOpenCart(!openCart);
+    if (!openCart) setOpenOrders(false);
   };
 
   if (error) {
@@ -116,16 +142,30 @@ const ProfilePage = () => {
           <Typography variant="body1"><strong>Address:</strong> {profile.address || 'Not provided'}</Typography>
         </div>
       </div>
+
+      {/* clickable items to show the user's past Orders and Cart content */}
       <div style={{ marginTop: '20px' }}>
-        {/* Orders Section */}
-        <Typography
-          variant="h6"
-          color="primary"
-          onClick={handleToggleOrders}
-          style={{ cursor: 'pointer', textDecoration: 'underline', marginBottom: '10px' }}
-        >
-          Orders
-        </Typography>
+        <div style={{ display: 'flex', gap: '30px', alignItems: 'center', marginBottom: '10px' }}>
+          {/* Orders Section */}
+          <Typography
+            variant="h6"
+            color={openOrders ? "primary" : "inherit"}
+            onClick={handleToggleOrders}
+            style={{ cursor: 'pointer', textDecoration: openOrders ? 'underline' : 'none' }}
+          >
+            Orders
+          </Typography>
+          {/* Cart Section */}
+          <Typography
+            variant="h6"
+            color={openCart ? "primary" : "inherit"}
+            onClick={handleToggleCart}
+            style={{ cursor: 'pointer', textDecoration: openCart ? 'underline' : 'none', display: 'flex', alignItems: 'center' }}
+          >
+            <ShoppingCartIcon fontSize="small" style={{ marginRight: 4 }} />
+            Cart
+          </Typography>
+        </div>
 
         <Collapse in={openOrders}>
           <div>
@@ -159,6 +199,53 @@ const ProfilePage = () => {
                     </ListItem>
                   </div>
                 ))}
+              </List>
+            )}
+          </div>
+        </Collapse>
+
+        {/* Cart Dropdown */}
+        <Collapse in={openCart}>
+          <div>
+            <h2>Your Cart</h2>
+            {cart.items.length === 0 ? (
+              <p>Your cart is empty.</p>
+            ) : (
+              <List>
+                {cart.items.map((item, idx) => (
+                  <div key={idx}>
+                    <ListItem
+                      style={{
+                        padding: '15px',
+                        border: '2px solid #ddd',
+                        marginBottom: '10px',
+                        borderRadius: '8px',
+                        alignItems: 'flex-start'
+                      }}
+                    >
+                      <ListItemText
+                        primary={
+                          <span>
+                            <strong>{item.name}</strong>
+                          </span>
+                        }
+                        secondary={
+                          <>
+                            <div>Size: {item.size_name}</div>
+                            <div>Color: {item.color_name}</div>
+                            <div>Price: ${item.price}</div>
+                            <div>Quantity: {item.quantity}</div>
+                          </>
+                        }
+                      />
+                    </ListItem>
+                  </div>
+                ))}
+                <ListItem>
+                  <ListItemText
+                    primary={<strong>Total: ${cart.total_price}</strong>}
+                  />
+                </ListItem>
               </List>
             )}
           </div>

--- a/frontend/src/ProfilePage.js
+++ b/frontend/src/ProfilePage.js
@@ -243,7 +243,19 @@ const ProfilePage = () => {
                     </ListItem>
                   </div>
                 ))}
-                <ListItem>
+                {/* show the total and the checkout button */}
+                <ListItem
+                  secondaryAction={
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      size="small"
+                      onClick={() => navigate("/checkout")}
+                    >
+                      Check Out
+                    </Button>
+                  }
+                >
                   <ListItemText
                     primary={<strong>Total: ${cart.total_price}</strong>}
                   />


### PR DESCRIPTION
# Overview
In reference to #161 
This PR is about adding the feature of showing cart information on the user's profile page. Some other UI updates have happened as well.

![image](https://github.com/user-attachments/assets/e02f82b8-eacb-4e2e-8077-2fb54392c7bf)

## Info
1. We now have a "Cart" section on the profile page. 
2. It shows the products that the user has added to their cart previously. 
3. The items show general info, _and_ also include a thumbnail picture of the product.
4. The cart and orders sections are **collapse-able**.
5. I had to update the backend for `models/cart.js` a bit to make the image feature work. Just a simple inclusion of `image_url`.
6. And there's also a "Check Out" button once the user looks to the right of the price total.
7. I also added 2 Material UI icons for the sake of UI/UX improvements. 