### PR TITLE
Reviews update: updating error messages and updating posted reviews (Issue #169)

### DIFF
--- a/frontend/src/pages/ProductPage.js
+++ b/frontend/src/pages/ProductPage.js
@@ -125,7 +125,16 @@ const ProductPage = () => {
       alert('Review submitted! It will appear after approval.');
     } catch (error) {
       console.error('Error submitting review:', error.response?.data || error.message);
-      alert('Failed to submit review');
+    
+      const msg = error?.response?.data?.message;
+    
+      if (msg === "You have already reviewed this product") {
+        alert("You’ve already reviewed this product.");
+      } else if (msg === "You can only review products you have purchased and received") {
+        alert("You can only review products you’ve purchased and received.");
+      } else {
+        alert("Failed to submit review.");
+      }
     }
   };
 


### PR DESCRIPTION
### PR for handling issue #169 

First problem, "Non-informative Error Message when User Posts Reviews for the Same Products" is handled. Now if the user tries to review a product they've already reviewed they will get the "You’ve already reviewed this product." error message. It can be seen in this screenshot (I tried as ratingsreviewstestperson my previous review is at the top)
<img width="1440" alt="Screenshot 2025-05-08 at 01 49 24" src="https://github.com/user-attachments/assets/22914374-7d67-4650-a28c-7543d355d76a" />

Additionally, if the user tries to review random products that they haven't purchased or the products that they purchased but haven't delivered yet, they'll get the "You can only review products you’ve purchased and received." error message.
<img width="1440" alt="Screenshot 2025-05-08 at 01 49 56" src="https://github.com/user-attachments/assets/9f4778dd-4c19-4846-a49d-0fd7dd725680" />


I'm currently working on the other part of this issue: updating reviews.