### PR TITLE
Fix for the Checkout Forgetting User Auth - Bug 187

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -48,7 +48,7 @@ function App() {
         <Route
           path="/invoice/:orderId"
           element={
-            <ProtectedRoute>
+            <ProtectedRoute role="customer">
               <InvoicePage />
             </ProtectedRoute>
           }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -27,7 +27,7 @@ function App() {
         <Route
           path="/checkout"
           element={
-            <ProtectedRoute>
+            <ProtectedRoute role="customer">
               <CheckoutPage />
             </ProtectedRoute>
           }

--- a/frontend/src/components/MiniCart.js
+++ b/frontend/src/components/MiniCart.js
@@ -193,7 +193,10 @@ const MiniCart = ({ anchorEl, open, onClose }) => {
               fullWidth
               onClick={() => {
                 onClose();
-                navigate("/checkout");
+                navigate(
+                  "/checkout",
+                  { state: { role: "customer" } }
+                );
               }}
             >
               Check Out

--- a/frontend/src/components/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute.js
@@ -1,9 +1,10 @@
 import React from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate , useLocation} from "react-router-dom";
 import { jwtDecode } from "jwt-decode";
 
 const ProtectedRoute = ({ children, role }) => {
   const token = localStorage.getItem("token");
+  const location = useLocation();
 
   if (!token) {
     // Redirect based on the expected role
@@ -26,8 +27,11 @@ const ProtectedRoute = ({ children, role }) => {
       return <Navigate to="/login" />;
     }
 
+    // Use role from state or fallback to JWT
+    const expectedRole = location.state?.role || decodedToken.role;
+    
     // Check if the role matches
-    if (decodedToken.role !== role) {
+    if (decodedToken.role !== expectedRole) {
       return <Navigate to="/login" />;
     }
   } catch (error) {


### PR DESCRIPTION
# Overview
In reference to #187 .
This code fixes the issue about not being able to go from cart to checkout (either mini cart on landing page and/or cart tab on profile page), even if the user is already logged in.

cc. @zeynepyaman 

## Info
Basically, the issue was that after writing the code for manager authentication, PR #186 , I changed the logic for navigation that would look at protected pages, and would check their `role` parameter. Now, the files `App.js`, `Minicart.js` and `ProtectedRoute.js` properly handle everything.

## Screenshots
To double check, let's start the project and begin the test from a state of having no authentication (being logged out).

![image](https://github.com/user-attachments/assets/a88ae5b1-5ee6-45df-9426-7c2703ca84c9)

Let's log in and add some stuff to our cart. I chose the user with email address `newuser1@example.com` with the password `password1234` (this user was manually added, hence not having a complex password, otherwise, our `Signup.js` page would throw an error for having a weak password).

![image](https://github.com/user-attachments/assets/d853d061-4dc4-4786-9ec4-d23cbb4bab0b)

Now let's try to check out again (now that we are logged in and have some items in our cart):

![image](https://github.com/user-attachments/assets/be3edd49-bc8b-4102-bac9-40ab2e20e167)

It successfully goes to the checkout page as `http://localhost:3000/checkout` with the correct items in our cart. And now, let's try to complete our order:

![image](https://github.com/user-attachments/assets/512707f9-eead-4a8c-8969-f29e551d5b77)

And our order was placed successfully and we can see our invoice page:

![image](https://github.com/user-attachments/assets/a475a2d0-ce6f-4890-b4a1-5ecece7fdc62)

Since I know it's the latest order, I can go to the customer's profile and scroll down until I read order with ID 21:

![image](https://github.com/user-attachments/assets/557df215-1184-4ea1-9bda-df1175f5fe28)

By clicking on that item, we can actually check the order status successfully:

![image](https://github.com/user-attachments/assets/33fc4820-78d9-44fa-9291-dcae7cf1fa5c)

So everything works fine.

### Checking Manager Authentication for Good Measure
Let's also try to log in as a manager to make sure nothing is broken here. The URL is `http://localhost:3000/manager-login`:

![image](https://github.com/user-attachments/assets/ac7aebc0-e4c1-43ff-96ba-775858cb18b7)

And it successfully takes us to the product manager page (since I chose a product manager for this example, works with sales manager too):

![image](https://github.com/user-attachments/assets/82aa9354-01d0-4301-9dab-72cc7445db00)

So indeed, everything is working fine now.
