### PR TITLE
Endpoints for sales stats calculations

### DIFF
--- a/backend/src/controllers/orderController.js
+++ b/backend/src/controllers/orderController.js
@@ -182,3 +182,44 @@ exports.getOrderWithItems = async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 };  
+
+exports.getProductSalesStats = async (req, res) => {
+  try {
+    if (req.user.role !== 'salesManager') {
+      return res.status(403).json({ message: "Only sales managers can access product sales stats." });
+    }
+
+    const stats = await Order.getProductSalesStats();
+    res.status(200).json(stats);
+  } catch (err) {
+    res.status(500).json({ error: "Failed to fetch product sales stats" });
+  }
+};
+
+exports.getVariationSalesStats = async (req, res) => {
+  try {
+    if (req.user.role !== 'salesManager') {
+      return res.status(403).json({ message: "Only sales managers can access variation sales stats." });
+    }
+
+    const stats = await Order.getVariationSalesStats();
+    res.status(200).json(stats);
+  } catch (err) {
+    res.status(500).json({ error: "Failed to fetch variation sales stats" });
+  }
+};
+
+exports.getVariationSalesStatsByProduct = async (req, res) => {
+  try {
+    if (req.user.role !== 'salesManager') {
+      return res.status(403).json({ message: "Only sales managers can access variation sales stats." });
+    }
+
+    const productId = req.params.productId;
+    const stats = await Order.getVariationSalesStatsByProductId(productId);
+    res.status(200).json(stats);
+  } catch (err) {
+    console.error("Variation stats error:", err);
+    res.status(500).json({ error: "Failed to fetch variation stats for product" });
+  }
+};

--- a/backend/src/database/products_schema.sql
+++ b/backend/src/database/products_schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS products (
     name VARCHAR(255) NOT NULL,
     description TEXT,
     price DECIMAL(10,2) NOT NULL,
+    cost DECIMAL(10, 2),
     department_id BIGINT UNSIGNED NOT NULL,
     category_id BIGINT UNSIGNED NOT NULL,
     material VARCHAR(255),
@@ -15,3 +16,15 @@ CREATE TABLE IF NOT EXISTS products (
     FOREIGN KEY (department_id) REFERENCES departments(department_id) ON DELETE CASCADE,
     FOREIGN KEY (category_id) REFERENCES categories(category_id) ON DELETE CASCADE
 );
+
+DELIMITER $$
+
+CREATE TRIGGER set_cost_default
+BEFORE INSERT ON products
+FOR EACH ROW
+BEGIN
+    IF NEW.cost IS NULL THEN
+        SET NEW.cost = NEW.price / 2;
+    END IF;
+END $$
+DELIMITER ;

--- a/backend/src/routes/orderRoutes.js
+++ b/backend/src/routes/orderRoutes.js
@@ -10,5 +10,8 @@ router.get("/with-items/:id", authMiddleware, orderController.getOrderWithItems)
 router.get("/:id", orderController.getOrderById);
 router.patch("/:id/status", orderController.updateOrderStatus);
 router.delete("/:id", orderController.deleteOrder);
+router.get("/stats/products", authMiddleware, orderController.getProductSalesStats);
+router.get("/stats/variations", authMiddleware, orderController.getVariationSalesStats);
+router.get("/stats/variations/product/:productId", authMiddleware, orderController.getVariationSalesStatsByProduct);
 
 module.exports = router;


### PR DESCRIPTION
### **1) Added a cost column to products table.**
Also added a mysql trigger for product insertion. If when a product is inserted, the cost is null, then it defaults it to half of the price.

To manually add the column and trigger run these:

`ALTER TABLE products ADD COLUMN cost DECIMAL(10, 2) AFTER price;`
```
DELIMITER $$

CREATE TRIGGER set_cost_default
BEFORE INSERT ON products
FOR EACH ROW
BEGIN
    IF NEW.cost IS NULL THEN
        SET NEW.cost = NEW.price / 2;
    END IF;
END$$

DELIMITER ;
```
And to assign the existing products we have the cost of half their prices:

```
UPDATE products
SET cost = price / 2
WHERE cost IS NULL;
```

If you want to test this you can add this random product, 
```
INSERT IGNORE INTO products (
  serial_number, name, description, price, cost, department_id,  category_id, material, image_url, stock_quantity,
  warranty_status, distributor_info, popularity_score
) VALUES (
  'SN00', 'stock test product', 'testing testing', 10.00, NULL, 3, 48, 'Cotton', 'url_SN30', 125, '1 Year', 'DistK', 5.0
);
```
run this in mysql. as you can see the cost value is null. this product is inserted as:

<img width="1129" alt="Screenshot 2025-05-14 at 03 12 57" src="https://github.com/user-attachments/assets/7c963e2f-0178-4dda-bad2-cbf4e118501a" />

where cost is auto assigned as 10/2 = 5.

Now if you want remove this testing product from the database to not run issues in the future, run this to delete the row and reset the auto increment:
```
DELETE FROM products WHERE product_id = 16;
ALTER TABLE products AUTO_INCREMENT = 16;
```

### **2) Endpoints**

NOTE: All 3 methods require a salesManager user and also need a JWT bearer token. 
NOTE 2: Your results and total values might differ based on your order table.

**- Product Sales Stats**
Returns total_units_sold, total_revenue, total_profit  per product.

GET http://localhost:5001/api/orders/stats/products
curl: curl -X GET http://localhost:5001/api/orders/stats/products \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"

<img width="1060" alt="Screenshot 2025-05-14 at 03 20 52" src="https://github.com/user-attachments/assets/d27ccf3b-cffc-4897-8699-a0d56d61307f" />


NOTE 3: Variation names are the variation serial numbers.

**- All Variations Sales Stats**
Returns  total_units_sold, total_revenue, total_profit per every variation of every product (that has orders).

GET  http://localhost:5001/api/orders/stats/variations
curl: curl -X GET http://localhost:5001/api/orders/stats/variations \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"

<img width="1060" alt="Screenshot 2025-05-14 at 03 23 12" src="https://github.com/user-attachments/assets/37f3767c-d629-4242-8d48-9ef170ebe2ce" />



**- Each Product's Variation Stats**
Returns  total_units_sold, total_revenue, total_profit for all variations (that has orders) per requested product.

GET http://localhost:5001/api/orders/stats/variations/product/1
curl: curl -X GET http://localhost:5001/api/orders/stats/variations/product/1 \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"

Here is the results for product_ids 1 and 9:
<img width="1060" alt="Screenshot 2025-05-14 at 03 23 48" src="https://github.com/user-attachments/assets/85316791-308d-4764-a6ce-f8d573da228b" />

<img width="1060" alt="Screenshot 2025-05-14 at 03 24 45" src="https://github.com/user-attachments/assets/484a58f8-9e81-45bd-959c-5239e2aa8c9c" />


