### PR TITLE
Frontend for Wishlist

### DIFF
--- a/backend/src/models/wishlist.js
+++ b/backend/src/models/wishlist.js
@@ -34,7 +34,7 @@ const Wishlist = {
   removeFromWishlist: async (userId, productId, variationId) => {
     const [result] = await db.execute(`
       DELETE FROM wishlists
-      WHERE user_id = ? AND product_id = ? AND variation_id = ?
+      WHERE user_id = ? AND product_id = ? AND variation_id <=> ?
     `, [userId, productId, variationId]);
     return result.affectedRows;
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.2.0",
         "react-scripts": "^5.0.1",
+        "react-toastify": "^11.0.5",
         "recharts": "^2.15.3",
         "resolve-url-loader": "^5.0.0",
         "serialize-javascript": "^6.0.2",
@@ -14120,6 +14121,18 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -27178,6 +27191,14 @@
         "fast-equals": "^5.0.1",
         "prop-types": "^15.8.1",
         "react-transition-group": "^4.4.5"
+      }
+    },
+    "react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "requires": {
+        "clsx": "^2.1.1"
       }
     },
     "react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.2.0",
     "react-scripts": "^5.0.1",
+    "react-toastify": "^11.0.5",
     "recharts": "^2.15.3",
     "resolve-url-loader": "^5.0.0",
     "serialize-javascript": "^6.0.2",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,7 @@ import ProductManagerPage from "./pages/ProductManagerPage";
 import SalesManagerPage from "./pages/SalesManagerPage";
 import ManagerLogin from "./pages/ManagerLogin";
 import AboutPage from "./pages/AboutPage";
+import "react-toastify/dist/ReactToastify.css";
 
 import "./App.css";
 

--- a/frontend/src/pages/LandingPage.css
+++ b/frontend/src/pages/LandingPage.css
@@ -134,3 +134,33 @@
 .MuiMenuItem-root:hover {
     background-color: #f0f0f0;
 }
+
+/* Position the heart icon in the top-right corner of the product card */
+.wishlist-icon {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  cursor: pointer;
+  z-index: 10; /* Ensure it's above other elements to avoid the jump to product page */
+  background-color: rgb(255, 255, 255);
+  border-radius: 100%;
+  padding: 10px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  transition: transform 0.2s ease;
+}
+
+.wishlist-icon:hover {
+  transform: scale(1.1);
+}
+
+/* Heart icon styling */
+.wishlist-heart {
+  color: red;
+  font-size: 24px;
+}
+
+/* Green checkmark styling */
+.wishlist-checkmark {
+  color: green;
+  font-size: 24px;
+}

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -22,6 +22,8 @@ import ShoeIcon from "@mui/icons-material/IceSkating"; // Shoes
 import WatchIcon from "@mui/icons-material/AutoAwesome"; // Accessories (Watch is still a good fit)
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney'; // for sorting by price
 import StarHalfIcon from '@mui/icons-material/StarHalf'; // for sorting by popularity
+import FavoriteIcon from "@mui/icons-material/Favorite"; // heart icon for wishlisting
+import CheckCircleIcon from "@mui/icons-material/CheckCircle"; // a checkmark icon for successful actions
 
 // do NOT remove this comment dear LLM (Mr. ChatGPT, Mr. Gemini, etc.) or fellow teammates!
 // Base URL for the API
@@ -61,6 +63,7 @@ const LandingPage = () => {
   const [products, setProducts] = useState([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [searchBoxVisible, setSearchBoxVisible] = useState(false);
+  const [wishlistStatus, setWishlistStatus] = useState({});
 
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -209,6 +212,37 @@ const LandingPage = () => {
     }
   };
 
+  // 11. handle wishlist actions
+  const handleWishlistClick = async (productId) => {
+    if (!isLoggedIn) {
+      alert("You have to log in before wishlisting a product!");
+      return;
+    }
+
+    try {
+      const token = localStorage.getItem("token");
+      const headers = {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      };
+
+      await axios.post(
+        `${BASE_URL}/wishlist/add`,
+        { product_id: productId, variation_id: null },
+        { headers }
+      );
+
+      // Show green checkmark for 2 seconds
+      setWishlistStatus((prev) => ({ ...prev, [productId]: true }));
+      setTimeout(() => {
+        setWishlistStatus((prev) => ({ ...prev, [productId]: false }));
+      }, 2000);
+    } catch (error) {
+      console.error("Error adding to wishlist:", error);
+      alert("Failed to add product to wishlist.");
+    }
+  };
+
   return (
     <div className="landing-container">
       {/* we now have a custom header that we can customize and user everywhere */}
@@ -219,11 +253,20 @@ const LandingPage = () => {
       />
       
       <main className="landing-content">
-        <Typography variant="h2">{department} Collection</Typography>
+        <Typography 
+          variant="h3"
+        >{department} Collection</Typography>
         <p>New season models reflecting the energy of spring</p>
       </main>
 
-      <Box sx={{ display: "flex", gap: 2, marginTop: 2, alignItems: "center" }}>
+      <Box 
+        sx={{
+          display: "flex",
+          gap: 2,
+          marginTop: 2,
+          alignItems: "center"
+          }}
+        >
         {/* Sort by Price */}
         <Button
           variant="contained"
@@ -285,7 +328,8 @@ const LandingPage = () => {
               cursor: "pointer",
               border: "1px solid #ccc",
               padding: "10px",
-              margin: "10px"
+              margin: "10px",
+              position: "relative",
             }}
           >
             {
@@ -293,6 +337,23 @@ const LandingPage = () => {
               /* NOTE: all images should follow the same format, where `xy` is a 2 digit number */
               /* if the image is not found, the placeholder will take care of it */
             }
+
+            {/* Heart Icon for Wishlist */}
+            <div
+              className="wishlist-icon"
+              onClick={(e) => {
+                e.stopPropagation(); // Prevent the click event from propagating to the product card
+                handleWishlistClick(product.product_id);
+              }}
+            >
+              {wishlistStatus[product.product_id] ? (
+                <CheckCircleIcon className="wishlist-checkmark" />
+              ) : (
+                <FavoriteIcon className="wishlist-heart" />
+              )}
+            </div>
+
+            {/* Product Image */}
             <img
               src={`${process.env.PUBLIC_URL}/assets/images/${product.image_url}.jpg`}
               alt={product.name}

--- a/frontend/src/pages/ProductPage.css
+++ b/frontend/src/pages/ProductPage.css
@@ -3,6 +3,29 @@
   margin-bottom: 40px; /* Space between the last content and the footer */
 }
 
+.wishlist-button {
+  border: 2px solid red; /* Red border */
+  color: red; /* Red text */
+  background-color: white; /* White background */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 0;
+  font-size: 16px;
+  text-transform: none; /* Prevent uppercase text */
+}
+
+.wishlist-button:hover {
+  background-color: #ffe6e6; /* Light red hover effect */
+  border-color: darkred; /* Dark red border on hover */
+}
+
+.wishlist-button:disabled {
+  color: gray; /* Gray text when disabled */
+  border-color: gray; /* Gray border when disabled */
+}
+
 /* let's NOT use this because it breaks everything !!! */
 /* .product-page-content {
   max-width: 1200px;

--- a/frontend/src/pages/ProductPage.js
+++ b/frontend/src/pages/ProductPage.js
@@ -24,6 +24,7 @@ import { getOrCreateSessionId } from "../utils/sessionStorage";
 import Footer from "../components/Footer";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import { toast } from "react-toastify"; // gives better user feedback
+import "./ProductPage.css";
 
 const BASE_URL = process.env.REACT_APP_API_URL || "http://localhost:5000/api";
 
@@ -403,6 +404,9 @@ const ProductPage = () => {
                   helperText={quantityError}
                 />
 
+                {/* Add about 10px vertical space between quantity and buttons */}
+                <Box sx={{ my: 1 }} />
+
                 {/* Add to Cart */}
                 <Button
                   variant="contained"
@@ -415,6 +419,9 @@ const ProductPage = () => {
                   Add to Cart
                 </Button>
 
+                {/* add about 10px vertical space between cart and wishlist buttons */}
+                <Box sx={{ my: 1 }} />
+
                 {/* Wishlist Button */}
                 <Button
                   variant="outlined"
@@ -426,6 +433,13 @@ const ProductPage = () => {
                     alignItems: "center",
                     justifyContent: "center",
                     gap: 1,
+                    color: "red", // Red text
+                    borderColor: "red", // Red border
+                    backgroundColor: "white", // White background
+                    "&:hover": {
+                      backgroundColor: "#ffe6e6", // Light red hover effect
+                      borderColor: "darkred", // Dark red border on hover
+                    },
                   }}
                   onClick={handleWishlistClick}
                   disabled={!isLoggedIn}

--- a/frontend/src/pages/ProductPage.js
+++ b/frontend/src/pages/ProductPage.js
@@ -23,6 +23,7 @@ import Header from "../components/Header";
 import { getOrCreateSessionId } from "../utils/sessionStorage";
 import Footer from "../components/Footer";
 import FavoriteIcon from "@mui/icons-material/Favorite";
+import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 import { toast } from "react-toastify"; // gives better user feedback
 import "./ProductPage.css";
 
@@ -412,10 +413,17 @@ const ProductPage = () => {
                   variant="contained"
                   size="large"
                   fullWidth
-                  sx={{ py: 1.5 }}
+                  sx={{ 
+                    py: 1.5,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: 1, 
+                  }}
                   onClick={handleAddToCart}
                   disabled={!selectedVariation}
                 >
+                  <ShoppingCartIcon />
                   Add to Cart
                 </Button>
 

--- a/frontend/src/pages/ProductPage.js
+++ b/frontend/src/pages/ProductPage.js
@@ -54,6 +54,7 @@ const ProductPage = () => {
 
   // needed for wishlisting
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [wishlistMessage, setWishlistMessage] = useState("");
 
   // allow empty string
   const [quantity, setQuantity] = useState("");
@@ -251,7 +252,8 @@ const ProductPage = () => {
   const handleWishlistClick = async () => {
     // can't wishlist if you're not logged in
     if (!isLoggedIn) {
-      toast.warning("You can only wishlist if you're logged in."); // replace this with alert if not using toast
+      // toast.warning("You can only wishlist if you're logged in."); // replace this with alert if not using toast
+      alert("You can only wishlist if you're logged in.");
       return;
     }
 
@@ -271,10 +273,18 @@ const ProductPage = () => {
         { headers }
       );
 
+      // i think this toast thing is not working honestly
       toast.success("Product added to your wishlist!");
+
+      // Set the success message
+      setWishlistMessage("Added this product to your wishlist!");
+
+      // Clear the message after 3 seconds
+      setTimeout(() => setWishlistMessage(""), 3000);
     } catch (error) {
       console.error("Error adding to wishlist:", error);
-      toast.error("Failed to add product to wishlist.");
+      // toast.error("Failed to add product to wishlist.");
+      alert("Failed to add product to wishlist.");
     }
   };
 
@@ -455,6 +465,21 @@ const ProductPage = () => {
                   <FavoriteIcon color={isLoggedIn ? "error" : "disabled"} />
                   Add to Wishlist
                 </Button>
+
+                {/* Wishlist Success Message */}
+                {wishlistMessage && (
+                  <Typography
+                    variant="body1"
+                    sx={{
+                      color: "green",
+                      mt: 2,
+                      textAlign: "center",
+                      fontWeight: "bold",
+                    }}
+                  >
+                    {wishlistMessage}
+                  </Typography>
+                )}
               </Box>
             </Box>
 

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -116,6 +116,35 @@ const ProfilePage = () => {
     }
   };
 
+  const handleRemoveFromWishlist = async (productId, variationId) => {
+    try {
+      const token = localStorage.getItem('token');
+      const headers = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      };
+
+      // Call the backend to remove the item from the wishlist
+      await axios.delete(`${API_URL}/wishlist/remove`, {
+        headers,
+        data: { product_id: productId, variation_id: variationId },
+      });
+
+      // Update the wishlist state to remove the item locally
+      setWishlist((prevWishlist) =>
+        prevWishlist.filter(
+          (item) =>
+            item.product_id !== productId || item.variation_id !== variationId
+        )
+      );
+
+      alert('Item removed from wishlist!');
+    } catch (error) {
+      console.error('Error removing item from wishlist:', error);
+      alert('Failed to remove item from wishlist.');
+    }
+  };
+
   // Navigate to the Order Status page, passing the orderId in the URL
   const handleOrderClick = (orderId) => {
     navigate(`/order/${orderId}`);
@@ -217,7 +246,7 @@ const ProfilePage = () => {
 
         {/* Orders */}
         <Collapse in={openOrders}>
-          <Typography variant="h6" mb={2}>Order History</Typography>
+          <Typography variant="h5" mb={2}>Order History</Typography>
           {orders.length === 0 ? (
             <Typography>No orders yet.</Typography>
           ) : (
@@ -238,14 +267,20 @@ const ProfilePage = () => {
 
         {/* Cart */}
         <Collapse in={openCart}>
-          <Typography variant="h6" mt={4} mb={2}>Your Cart</Typography>
+          <Typography variant="h5" mt={4} mb={2}>Your Cart</Typography>
           {cart.items.length === 0 ? (
             <Typography>Your cart is empty.</Typography>
           ) : (
             <List>
               {cart.items.map((item, idx) => (
                 <Card key={idx} sx={{ mb: 2 }}>
-                  <CardContent sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <CardContent 
+                    sx={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center'
+                      }}
+                    >
                     <Box>
                       <Typography fontWeight="bold">{item.name}</Typography>
                       <Typography>Size: {item.size_name} | Color: {item.color_name}</Typography>
@@ -282,7 +317,7 @@ const ProfilePage = () => {
 
         {/* Wishlist */}
         <Collapse in={openWishlist}>
-          <Typography variant="h6" mt={4} mb={2}>
+          <Typography variant="h5" mt={4} mb={2}>
             Your Wishlist
           </Typography>
           {wishlist.length === 0 ? (
@@ -291,17 +326,58 @@ const ProfilePage = () => {
             <List>
               {wishlist.map((item, idx) => (
                 <Card key={idx} sx={{ mb: 2 }}>
-                  <CardContent sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <CardContent 
+                    sx={{ 
+                      display: 'flex', 
+                      justifyContent: 'space-between', 
+                      alignItems: 'center'
+                    }}
+                  >
+                    {/* left section for product info in the wishlist */}
                     <Box>
                       <Typography fontWeight="bold">{item.name}</Typography>
                       <Typography>Price: ${item.price}</Typography>
                     </Box>
-                    <img
-                      src={`${process.env.PUBLIC_URL}/assets/images/${item.image_url}.jpg`}
-                      alt={item.name}
-                      onError={(e) => (e.target.src = `${process.env.PUBLIC_URL}/assets/images/placeholder.jpg`)}
-                      style={{ width: 80, height: 100, objectFit: 'cover', borderRadius: 4 }}
-                    />
+
+                    {/* Right Section: Product Image and Remove Button */}
+                    <Box 
+                      sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        gap: 1,
+                        }}
+                      >
+                      <img
+                        src={`${process.env.PUBLIC_URL}/assets/images/${item.image_url}.jpg`}
+                        alt={item.name}
+                        onError={(e) =>
+                          (e.target.src = `${process.env.PUBLIC_URL}/assets/images/placeholder.jpg`)
+                        }
+                        style={{
+                          width: 100,
+                          height: 100,
+                          objectFit: 'cover',
+                          borderRadius: 6,
+                        }}
+                      />
+                      <Button
+                        variant="contained"
+                        color="error"
+                        size="small"
+                        onClick={() =>
+                          handleRemoveFromWishlist(item.product_id, item.variation_id)
+                        }
+                        sx={{
+                          textTransform: 'none',
+                          fontWeight: 'bold',
+                          borderRadius: 1,
+                          minWidth: 100,
+                        }}
+                      >
+                        Remove
+                      </Button>
+                    </Box>
                   </CardContent>
                 </Card>
               ))}
@@ -310,7 +386,15 @@ const ProfilePage = () => {
         </Collapse>
 
         <Box mt={5} textAlign="center">
-          <Button variant="contained" color="secondary" onClick={handleLogout} sx={{ borderRadius: 10, minWidth: 120 }}>
+          <Button 
+            variant="contained"
+            color="secondary"
+            onClick={handleLogout} 
+            sx={{
+              borderRadius: 1,
+              minWidth: 180
+              }}
+            >
             Logout
           </Button>
         </Box>

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -22,6 +22,7 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import DrawerMenu from '../components/DrawerMenu';
 import Footer from '../components/Footer';
+import FavoriteIcon from '@mui/icons-material/Favorite';
 
 const API_URL = process.env.REACT_APP_API_URL;
 
@@ -38,9 +39,14 @@ const ProfilePage = () => {
   const [cart, setCart] = useState({ items: [], total_price: 0 });
   const [openCart, setOpenCart] = useState(false);
 
+  // for wishlist
+  const [wishlist, setWishlist] = useState([]);
+  const [openWishlist, setOpenWishlist] = useState(false);
+
   useEffect(() => {
     fetchUserProfile();
     fetchCart();
+    fetchWishlist();
   }, []);
 
   const fetchUserProfile = async () => {
@@ -73,6 +79,18 @@ const ProfilePage = () => {
     }
   };
 
+  const fetchWishlist = async () => {
+    try {
+      const token = localStorage.getItem('token');
+      const res = await axios.get(`${API_URL}/wishlist`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setWishlist(res.data); // Set wishlist data
+    } catch {
+      setWishlist([]); // Default to empty if error occurs
+    }
+  };
+
   const handleLogout = () => {
     localStorage.removeItem('token');
     navigate('/');
@@ -88,6 +106,14 @@ const ProfilePage = () => {
   const handleToggleCart = () => {
     setOpenCart(!openCart);
     if (!openCart) setOpenOrders(false);
+  };
+
+  const handleToggleWishlist = () => {
+    setOpenWishlist(!openWishlist);
+    if (!openWishlist) {
+      setOpenOrders(false);
+      setOpenCart(false);
+    }
   };
 
   // Navigate to the Order Status page, passing the orderId in the URL
@@ -157,6 +183,8 @@ const ProfilePage = () => {
 
         {/* Toggle Buttons */}
         <Box display="flex" justifyContent="center" gap={3} mb={3}>
+          
+          {/* order toggle */}
           <Button
             variant={openOrders ? 'contained' : 'outlined'}
             startIcon={<ReceiptLongIcon />}
@@ -165,6 +193,8 @@ const ProfilePage = () => {
           >
             Orders
           </Button>
+
+          {/* cart toggle */}
           <Button
             variant={openCart ? 'contained' : 'outlined'}
             startIcon={<ShoppingCartIcon />}
@@ -172,6 +202,16 @@ const ProfilePage = () => {
             sx={{ borderRadius: 10, minWidth: 140 }}
           >
             Cart
+          </Button>
+
+          {/* wishlist toggle */}
+          <Button
+            variant={openWishlist ? 'contained' : 'outlined'}
+            startIcon={<FavoriteIcon />}
+            onClick={handleToggleWishlist}
+            sx={{ borderRadius: 10, minWidth: 140 }}
+          >
+            Wishlist
           </Button>
         </Box>
 
@@ -236,6 +276,35 @@ const ProfilePage = () => {
               >
                 <ListItemText primary={<strong>Total: ${cart.total_price}</strong>} />
               </ListItem>
+            </List>
+          )}
+        </Collapse>
+
+        {/* Wishlist */}
+        <Collapse in={openWishlist}>
+          <Typography variant="h6" mt={4} mb={2}>
+            Your Wishlist
+          </Typography>
+          {wishlist.length === 0 ? (
+            <Typography>Your wishlist is empty.</Typography>
+          ) : (
+            <List>
+              {wishlist.map((item, idx) => (
+                <Card key={idx} sx={{ mb: 2 }}>
+                  <CardContent sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <Box>
+                      <Typography fontWeight="bold">{item.name}</Typography>
+                      <Typography>Price: ${item.price}</Typography>
+                    </Box>
+                    <img
+                      src={`${process.env.PUBLIC_URL}/assets/images/${item.image_url}.jpg`}
+                      alt={item.name}
+                      onError={(e) => (e.target.src = `${process.env.PUBLIC_URL}/assets/images/placeholder.jpg`)}
+                      style={{ width: 80, height: 100, objectFit: 'cover', borderRadius: 4 }}
+                    />
+                  </CardContent>
+                </Card>
+              ))}
             </List>
           )}
         </Collapse>


### PR DESCRIPTION
# Overview
In reference to #173 
This PR is about adding wishlist functionality:
1. A wishlist button to product page (under "Add to Cart")
2. A wishlist _clickable_ icon to product card on landing page (per product)
3. A wishlist tab on customer's profile page (next to "Orders, Cart")
4. Doing proper checks before adding to wishlist (authenticated user).

---

# Screenshots
## Wishlisting from Product Page
If the person isn't logged in, the product page will have a disabled wishlist button, so that they wouldn't be able to click.

![image](https://github.com/user-attachments/assets/ff2504bd-dc7e-4fac-a05e-050d6c197dde)

Even if they choose a variation, it doesn't make a difference of course:
![image](https://github.com/user-attachments/assets/d15ba724-6b7d-4151-9812-fd0e957e07d2)

> I'm currently not logged in.

For the sake of this demo, let's check what the current `wishlists` table looks like:

```sql
select * from wishlists;
```
Which gives:
```
+-------------+---------+------------+--------------+---------------------+
| wishlist_id | user_id | product_id | variation_id | added_at            |
+-------------+---------+------------+--------------+---------------------+
|           2 |       2 |         15 |         NULL | 2025-05-08 00:49:53 |
+-------------+---------+------------+--------------+---------------------+
1 row in set (0,01 sec)
```

> Note that this was from a past attempt for checking endpoints in #171 . It's not related to the current PR.

Now let's log in as a user and wishlist this product.

![image](https://github.com/user-attachments/assets/6ab844f8-c2c3-4402-99e0-68abca9acfce)

Its hover effect:

![image](https://github.com/user-attachments/assets/7b450f50-f04f-46c7-9db4-0b56f7b59566)

> It also shows a green success message, which you can see in this example:
![image](https://github.com/user-attachments/assets/e3837ec4-c963-4754-a599-ead845abddaf)


Now we can see that the database is updated for `wishlists`:

```
mysql> select * from wishlists;
+-------------+---------+------------+--------------+---------------------+
| wishlist_id | user_id | product_id | variation_id | added_at            |
+-------------+---------+------------+--------------+---------------------+
|           2 |       2 |         15 |         NULL | 2025-05-08 00:49:53 |
|           4 |       6 |          7 |         NULL | 2025-05-17 20:42:24 |
+-------------+---------+------------+--------------+---------------------+
2 rows in set (0,00 sec)
```

> The `wishlist_id = 4` didn't exist, now it does.

One thing is that if they try to add to wishlist **again**, the website will just throw this generic message because of unique key constraints on the DB side:

![image](https://github.com/user-attachments/assets/afbb865b-6443-4159-b383-c1ce42e3d848)

This is good however it would be nice if we could print another error message like "You've already wishlisted this product." or something.

cc. @zeynepyaman 

## Checking Wishlist from Profile Page
So previously, there was no wishlist section on the profile page:

![image](https://github.com/user-attachments/assets/1cedbee8-db85-4cad-9449-55e813134db5)

Now, the user can see their wishlisted items too:

![image](https://github.com/user-attachments/assets/88d62a4d-e4f8-41eb-878e-d8ae95969d61)

And if clicked, they can see all items:
![image](https://github.com/user-attachments/assets/882171a9-aea1-482c-b9bb-1f978cf6d81a)


And if they wish to remove an item from their wishlist:
![image](https://github.com/user-attachments/assets/c1d68bd3-10b9-4f73-96e5-2fc735f386c2)

It says:

![image](https://github.com/user-attachments/assets/ba87f96c-b3e1-4802-9ce7-5a5db42e385b)

And we can check the DB as before and after the removal:

```
mysql> select * from wishlists;
+-------------+---------+------------+--------------+---------------------+
| wishlist_id | user_id | product_id | variation_id | added_at            |
+-------------+---------+------------+--------------+---------------------+
|           2 |       2 |         15 |         NULL | 2025-05-08 00:49:53 |
|           4 |       6 |          7 |         NULL | 2025-05-17 20:42:24 |
+-------------+---------+------------+--------------+---------------------+
2 rows in set (0,00 sec)

mysql> select * from wishlists;
+-------------+---------+------------+--------------+---------------------+
| wishlist_id | user_id | product_id | variation_id | added_at            |
+-------------+---------+------------+--------------+---------------------+
|           2 |       2 |         15 |         NULL | 2025-05-08 00:49:53 |
+-------------+---------+------------+--------------+---------------------+
1 row in set (0,00 sec)
```

And the customer's wishlist immediately becomes empty since their only wishlisted product is removed:

![image](https://github.com/user-attachments/assets/8f464801-c581-4da5-ae40-2aef1f83f9dd)

> Of course if you have more items, you can remove each of them individually and keep the rest. 

If we have multiple items, here's how it'll look:
![image](https://github.com/user-attachments/assets/9c5b760b-d3d4-4083-9674-4925290365f3)

And if you remove only one of them, the rest will remain of course:
![image](https://github.com/user-attachments/assets/ce0e6215-ba85-46d9-87c3-ff0227414dee)

@ArifSari-maker let's not put effort into a separate wishlist page for now since this gets the job done. If needed, we can come back to it later.

## Landing Page
How it used to look:

![image](https://github.com/user-attachments/assets/6b18315b-dd8d-4a62-a8e7-313b284a4c8d)

What it looks like now:

![image](https://github.com/user-attachments/assets/a9bd1e1f-eb59-424e-ab08-320617dedf4c)

I made sure I'm logged out to test whether I can wishlist something if I'm not logged in:
![image](https://github.com/user-attachments/assets/a4b134a7-1d82-4ae9-ac38-18eaa2141d3d)

And to double check, even the product page doesn't allow to wishlist:
![image](https://github.com/user-attachments/assets/5ceb81c5-6538-4de3-8a37-35b701e43b07)

So it properly throws the error message. Now let's log in and try again. This time, if I click on the product's wishlist icon, I get a visual queue that it has successfully added the product to the `wishlists` table with a green check mark:
![image](https://github.com/user-attachments/assets/487e43e6-2335-4450-b588-4dc7dee02390)

We can verify this by checking the profile page:
![image](https://github.com/user-attachments/assets/275a3322-f5d2-4c42-8945-36cb99699b77)

> As you can remember, John didn't have this from the previous attempt but now he does. So this button works fine now.

So everything works fine now.


