### PR TITLE
Updated order stats: Added status filtering + new endpoints with date

### DIFF
--- a/backend/src/models/order.js
+++ b/backend/src/models/order.js
@@ -38,6 +38,8 @@ const Order = {
         SUM(oi.quantity * (oi.price_at_purchase - p.cost)) AS total_profit
       FROM order_items oi
       JOIN products p ON oi.product_id = p.product_id
+      JOIN orders o ON oi.order_id = o.order_id
+      WHERE o.status NOT IN ('cancelled', 'refunded')
       GROUP BY p.product_id, p.name
     `);
     return rows;
@@ -56,6 +58,8 @@ const Order = {
       FROM order_items oi
       JOIN product_variations pv ON oi.variation_id = pv.variation_id
       JOIN products p ON pv.product_id = p.product_id
+      JOIN orders o ON oi.order_id = o.order_id
+      WHERE o.status NOT IN ('cancelled', 'refunded')
       GROUP BY pv.variation_id, pv.product_id
     `);
     return rows;
@@ -73,10 +77,71 @@ const Order = {
       FROM order_items oi
       JOIN product_variations pv ON oi.variation_id = pv.variation_id
       JOIN products p ON pv.product_id = p.product_id
-      WHERE pv.product_id = ?
+      JOIN orders o ON oi.order_id = o.order_id
+      WHERE pv.product_id = ? AND o.status NOT IN ('cancelled', 'refunded')
       GROUP BY pv.variation_id, pv.product_id, pv.serial_number
     `, [productId]);
 
+    return rows;
+  },
+
+  getDailyRevenueAndProfit : async () => {
+    const [rows] = await db.execute(`
+      SELECT 
+        DATE(o.order_date) AS date,
+        SUM(oi.quantity * oi.price_at_purchase) AS total_revenue,
+        SUM(oi.quantity * (oi.price_at_purchase - p.cost)) AS total_profit
+      FROM order_items oi
+      JOIN orders o ON oi.order_id = o.order_id
+      JOIN products p ON oi.product_id = p.product_id
+      WHERE o.status NOT IN ('cancelled', 'refunded')
+      GROUP BY DATE(o.order_date)
+      ORDER BY DATE(o.order_date)
+    `);
+    return rows;
+  },
+
+  getCumulativeRevenueAndProfit: async () => {
+    const [rows] = await db.execute(`
+      SELECT 
+        SUM(oi.quantity * oi.price_at_purchase) AS total_revenue,
+        SUM(oi.quantity * (oi.price_at_purchase - p.cost)) AS total_profit
+      FROM order_items oi
+      JOIN orders o ON oi.order_id = o.order_id
+      JOIN products p ON oi.product_id = p.product_id
+      WHERE o.status NOT IN ('cancelled', 'refunded')
+    `);
+    return rows[0];
+  },
+  
+  getCumulativeRevenueAndProfitBetweenDates: async (startDate, endDate) => {
+    const [rows] = await db.execute(`
+      SELECT 
+        SUM(oi.quantity * oi.price_at_purchase) AS total_revenue,
+        SUM(oi.quantity * (oi.price_at_purchase - p.cost)) AS total_profit
+      FROM order_items oi
+      JOIN orders o ON oi.order_id = o.order_id
+      JOIN products p ON oi.product_id = p.product_id
+      WHERE o.status NOT IN ('cancelled', 'refunded')
+        AND DATE(o.order_date) BETWEEN ? AND ?
+    `, [startDate, endDate]);
+    return rows[0];
+  },
+
+  getDailyRevenueAndProfitBetweenDates: async (startDate, endDate) => {
+    const [rows] = await db.execute(`
+      SELECT 
+        DATE(o.order_date) AS date,
+        SUM(oi.quantity * oi.price_at_purchase) AS total_revenue,
+        SUM(oi.quantity * (oi.price_at_purchase - p.cost)) AS total_profit
+      FROM order_items oi
+      JOIN orders o ON oi.order_id = o.order_id
+      JOIN products p ON oi.product_id = p.product_id
+      WHERE o.status NOT IN ('cancelled', 'refunded')
+        AND DATE(o.order_date) BETWEEN ? AND ?
+      GROUP BY DATE(o.order_date)
+      ORDER BY DATE(o.order_date)
+    `, [startDate, endDate]);
     return rows;
   }
 };

--- a/backend/src/routes/orderRoutes.js
+++ b/backend/src/routes/orderRoutes.js
@@ -13,5 +13,9 @@ router.delete("/:id", orderController.deleteOrder);
 router.get("/stats/products", authMiddleware, orderController.getProductSalesStats);
 router.get("/stats/variations", authMiddleware, orderController.getVariationSalesStats);
 router.get("/stats/variations/product/:productId", authMiddleware, orderController.getVariationSalesStatsByProduct);
+router.get('/stats/daily-revenue-profit', authMiddleware, orderController.getDailyRevenueAndProfit);
+router.get('/stats/cumulative', authMiddleware, orderController.getCumulativeRevenueAndProfit);
+router.get('/stats/cumulative/date-range', authMiddleware, orderController.getCumulativeRevenueAndProfitBetweenDates);
+router.get('/stats/daily-revenue-profit/date-range', authMiddleware, orderController.getDailyRevenueAndProfitBetweenDates);
 
 module.exports = router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
         "axios": "^1.9.0",
         "cors": "^2.8.5",
         "jwt-decode": "^4.0.0",
-        "react-router-dom": "^7.5.2"
+        "react-router-dom": "^7.5.2",
+        "react-toastify": "^11.0.5"
       }
     },
     "node_modules/asynckit": {
@@ -36,6 +37,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/combined-stream": {
@@ -361,6 +370,18 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -410,6 +431,11 @@
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       }
+    },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -614,6 +640,14 @@
       "integrity": "sha512-yk1XW8Fj7gK7flpYBXF3yzd2NbX6P7Kxjvs2b5nu1M04rb5pg/Zc4fGdBNTeT4eDYL2bvzWNyKaIMJX/RKHTTg==",
       "requires": {
         "react-router": "7.5.2"
+      }
+    },
+    "react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "requires": {
+        "clsx": "^2.1.1"
       }
     },
     "scheduler": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "axios": "^1.9.0",
     "cors": "^2.8.5",
     "jwt-decode": "^4.0.0",
-    "react-router-dom": "^7.5.2"
+    "react-router-dom": "^7.5.2",
+    "react-toastify": "^11.0.5"
   }
 }


### PR DESCRIPTION
NOTE: user must be a salesManager

### **1) Added status filtering to previously created functions so that refunded and cancelled orders are not included in revenue and profit calculations but remain on the tables so visible to the user.**

Here's an example: It can be seen I only have 1 entry for product 13 which is just one order:
<img width="1007" alt="Screenshot 2025-05-18 at 19 32 14" src="https://github.com/user-attachments/assets/a04c0429-bcb7-4f27-90f3-a8178c03cdcb" />
I update the status as 'cancelled'
<img width="789" alt="Screenshot 2025-05-18 at 19 44 22" src="https://github.com/user-attachments/assets/968cf347-889c-4da9-9e9d-778bc40444d5" />
And it doesn't show up anymore.
<img width="1005" alt="Screenshot 2025-05-18 at 19 45 08" src="https://github.com/user-attachments/assets/5cf6d8a0-a5a4-4d9a-9ae7-af3002f01603" />


### 2) Added new endpoints that utilizes dates to be used at frontend salesManager graphs.

-getDailyRevenueAndProfit
Returns daily profit and revenues.

GET http://localhost:5001/api/orders/stats/daily-revenue-profit
```
curl -X GET http://localhost:5001/api/orders/stats/daily-revenue-profit \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"

```
<img width="1005" alt="Screenshot 2025-05-19 at 03 07 59" src="https://github.com/user-attachments/assets/629a1492-5f2f-4b1a-96f2-9e2948fc5f6d" />


-getCumulativeRevenueAndProfit
Returns cumulative revenue and profit values for each day.

GET http://localhost:5001/api/orders/stats/cumulative

```
curl -X GET http://localhost:5001/api/orders/stats/cumulative \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"

```
<img width="1005" alt="Screenshot 2025-05-19 at 03 06 15" src="https://github.com/user-attachments/assets/3655918f-059b-4905-913c-ac3fb554b9f6" />

-getCumulativeRevenueAndProfitBetweenDates
Returns cumualtive revenue and profit values for each day between two given dates.

GET http://localhost:5001/api/orders/stats/cumulative/date-range?startDate=2025-05-01&endDate=2025-12-31”

```
curl -X GET "http://localhost:5001/api/orders/stats/cumulative/date-range?startDate=2025-05-01&endDate=2025-12-31" \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"
```
<img width="1005" alt="Screenshot 2025-05-19 at 03 03 22" src="https://github.com/user-attachments/assets/512453c3-423f-43aa-9bcd-d3be842d6514" />

-getDailyRevenueAndProfitBetweenDates
Returns daily revenue and profit values between two given dates.

GET http://localhost:5001/api/orders/stats/daily-revenue-profit/date-range?startDate=2025-05-01&endDate=2025-12-31

```
curl -X GET "http://localhost:5001/api/orders/stats/daily-revenue-profit/date-range?startDate=2025-05-01&endDate=2025-12-31" \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"
```

<img width="1005" alt="Screenshot 2025-05-19 at 03 04 57" src="https://github.com/user-attachments/assets/be61f0fd-910e-4754-b3a6-0a2a9faf09c1" />

### ------ These new functions has status filtering as well -------

After I updated my order with product_id 13 to processing, it can be seen that it's included in calculations again:
<img width="797" alt="Screenshot 2025-05-19 at 03 10 01" src="https://github.com/user-attachments/assets/42648c59-fdf8-4471-ba38-60a04a903be3" />

<img width="1004" alt="Screenshot 2025-05-19 at 03 10 27" src="https://github.com/user-attachments/assets/c3b4aa5c-62cb-4830-ba2d-b221c54fed57" />

<img width="1004" alt="Screenshot 2025-05-19 at 03 11 13" src="https://github.com/user-attachments/assets/c6f83750-712f-4cab-ade6-1a82576f1b4b" />

