### PR TITLE
Sales Manager Handling Returns (frontend, backend, database)

### DIFF
--- a/backend/src/controllers/returnsController.js
+++ b/backend/src/controllers/returnsController.js
@@ -28,10 +28,15 @@ exports.getAllReturns = async (req, res) => {
   try {
     const userId = req.user.user_id;
     const role = req.user.role;
+    const { status } = req.query; // if sales manager wants to filter by status
 
     let returns;
     if (role === 'salesManager') {
-      returns = await Returns.getAll();
+      if (status) {
+        returns = await Returns.getByStatus(status); // Filtered
+      } else {
+        returns = await Returns.getAll(); // All
+      }
     } else {
       returns = await Returns.getByUserId(userId);
     }

--- a/backend/src/controllers/returnsController.js
+++ b/backend/src/controllers/returnsController.js
@@ -1,18 +1,19 @@
 const Returns = require('../models/returns');
+const ProductVariations = require('../models/productVariations');
+const db = require('../config/database');
 
 exports.createReturn = async (req, res) => {
   try {
     const userId = req.user.user_id;
-    const { order_item_id, order_id, quantity, refund_amount } = req.body;
+    const { order_id, refund_amount } = req.body;
+    // no more order_item_id and quantity in the returns table
 
-    if (!order_item_id || !order_id) {
-      return res.status(400).json({ message: "order_item_id and order_id are required" });
+    if (!order_id) {
+      return res.status(400).json({ message: "order_id is required" });
     }
 
     const returnId = await Returns.create({
-      order_item_id,
       order_id,
-      quantity,
       refund_amount,
       user_id: userId
     });
@@ -23,6 +24,7 @@ exports.createReturn = async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 };
+
 
 exports.getAllReturns = async (req, res) => {
   try {
@@ -48,15 +50,60 @@ exports.getAllReturns = async (req, res) => {
   }
 };
 
+// exports.updateReturnStatus = async (req, res) => {
+//   try {
+//     const { status } = req.body;
+
+//     if (req.user.role !== 'salesManager') {
+//       return res.status(403).json({ message: "Only sales managers can approve or reject returns." });
+//     }
+
+//     await Returns.updateStatus(req.params.id, status);
+//     res.json({ message: "Return status updated" });
+//   } catch (err) {
+//     console.error("Update return status failed:", err);
+//     res.status(500).json({ error: err.message });
+//   }
+// };
+
 exports.updateReturnStatus = async (req, res) => {
   try {
     const { status } = req.body;
+    const returnId = req.params.id;
 
     if (req.user.role !== 'salesManager') {
       return res.status(403).json({ message: "Only sales managers can approve or reject returns." });
     }
 
-    await Returns.updateStatus(req.params.id, status);
+    // Get the return request to find the order_id
+    const [[ret]] = await db.execute("SELECT * FROM returns WHERE return_id = ?", [returnId]);
+    if (!ret) return res.status(404).json({ message: "Return request not found" });
+
+    // If approving, update stock and order status
+    if (status === 'approved') {
+      // Get all order items for this order
+      const [orderItems] = await db.execute(
+        "SELECT variation_id, quantity FROM order_items WHERE order_id = ?",
+        [ret.order_id]
+      );
+      // For each item, increase stock
+      for (const item of orderItems) {
+        if (item.variation_id && item.quantity) {
+          await ProductVariations.increaseStock(item.variation_id, item.quantity);
+        }
+      }
+      // Update order status to refunded
+      await db.execute(
+        "UPDATE orders SET status = 'refunded' WHERE order_id = ?",
+        [ret.order_id]
+      );
+    }
+
+    // If rejected, do NOT change order status (remains delivered)
+
+    // Update return status
+    await Returns.updateStatus(returnId, status);
+
     res.json({ message: "Return status updated" });
   } catch (err) {
     console.error("Update return status failed:", err);

--- a/backend/src/database/returns_schema.sql
+++ b/backend/src/database/returns_schema.sql
@@ -1,13 +1,10 @@
 CREATE TABLE IF NOT EXISTS returns (
   return_id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  order_item_id BIGINT UNSIGNED NOT NULL,
   order_id BIGINT UNSIGNED NOT NULL,
   user_id INT,
-  quantity INT UNSIGNED NOT NULL DEFAULT 1,
   refund_amount DECIMAL(10,2),
   status ENUM('pending', 'approved', 'rejected') DEFAULT 'pending',
   request_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (order_item_id) REFERENCES order_items(order_item_id) ON DELETE CASCADE,
   FOREIGN KEY (order_id) REFERENCES orders(order_id) ON DELETE CASCADE,
   FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE SET NULL
 );

--- a/backend/src/models/productVariations.js
+++ b/backend/src/models/productVariations.js
@@ -1,0 +1,12 @@
+const db = require('../config/database');
+
+const ProductVariations = {
+  increaseStock: async (variation_id, quantity) => {
+    await db.execute(
+      "UPDATE product_variations SET stock_quantity = stock_quantity + ? WHERE variation_id = ?",
+      [quantity, variation_id]
+    );
+  }
+};
+
+module.exports = ProductVariations;

--- a/backend/src/models/returns.js
+++ b/backend/src/models/returns.js
@@ -2,13 +2,12 @@ const db = require('../config/database');
 
 const Returns = {
   // Create a return and return the new return_id
-  create: async ({ order_item_id, order_id, quantity, refund_amount, user_id }) => {
+  create: async ({ order_id, refund_amount, user_id }) => {
+    // no more order_item_id and quantity in the returns table
     const [result] = await db.execute(
-      "INSERT INTO returns (order_item_id, order_id, quantity, refund_amount, user_id) VALUES (?, ?, ?, ?, ?)",
+      "INSERT INTO returns (order_id, refund_amount, user_id) VALUES (?, ?, ?)",
       [
-        order_item_id,
         order_id,
-        quantity ?? 1,
         refund_amount ?? null,
         user_id
       ]

--- a/backend/src/models/returns.js
+++ b/backend/src/models/returns.js
@@ -33,7 +33,13 @@ const Returns = {
       "UPDATE returns SET status = ? WHERE return_id = ?",
       [status, return_id]
     );
-  }
+  },
+  
+  // Get returns by status (for filtering)
+  getByStatus: async (status) => {
+    const [rows] = await db.execute("SELECT * FROM returns WHERE status = ?", [status]);
+    return rows;
+  },
 };
 
 module.exports = Returns;

--- a/frontend/src/pages/OrderStatusPage.js
+++ b/frontend/src/pages/OrderStatusPage.js
@@ -103,6 +103,7 @@ const OrderStatusPage = () => {
           <Typography>Order Number: {order.order_id}</Typography>
           <Typography>Order Date: {formatDate(order.order_date)}</Typography>
           <Typography>Total Price: ${order.total_price}</Typography>
+          <Typography>Order Status: {order.status}</Typography>
 
           <Box sx={{ my: 4 }}>
             <Stepper activeStep={currentStep} alternativeLabel>

--- a/frontend/src/pages/ProductPage.js
+++ b/frontend/src/pages/ProductPage.js
@@ -517,7 +517,7 @@ const ProductPage = () => {
                   </Typography>
                   {product.start_date && product.end_date && (
                     <Typography variant="body2" sx={{ mb: 1 }}>
-                      <strong>Sales from:</strong> {new Date(product.start_date).toLocaleDateString()} until {new Date(product.end_date).toLocaleDateString()}
+                      <strong>In Sale: </strong> from {new Date(product.start_date).toLocaleDateString()} until {new Date(product.end_date).toLocaleDateString()}
                     </Typography>
                   )}
 

--- a/frontend/src/pages/SalesManagerPage.js
+++ b/frontend/src/pages/SalesManagerPage.js
@@ -437,15 +437,15 @@ const SalesManagerPage = () => {
             </CardContent>
           </Card>
           );
-      case 'Price & Discounts':
+      case 'Price Management':
         return (
           <Card variant="outlined" style={{ marginBottom: '20px' }}>
             <CardContent>
-              <Typography variant="h6">Price & Discounts</Typography>
+              <Typography variant="h6">Price Management</Typography>
               <List>
                 <ListItem>- Set product prices</ListItem>
-                <ListItem>- Apply discounts to selected items</ListItem>
-                <ListItem>- Notify users with items in their wishlist</ListItem>
+                {/* <ListItem>- Apply discounts to selected items</ListItem> */}
+                {/* <ListItem>- Notify users with items in their wishlist</ListItem> */}
               </List>
             </CardContent>
           </Card>
@@ -598,18 +598,18 @@ const SalesManagerPage = () => {
             style={{
               cursor: 'pointer',
               marginBottom: '10px',
-              color: activeSection === 'Price & Discounts' ? '#1976d2' : 'inherit',
-              fontWeight: activeSection === 'Price & Discounts' ? 'bold' : 'normal',
+              color: activeSection === 'Price Management' ? '#1976d2' : 'inherit',
+              fontWeight: activeSection === 'Price Management' ? 'bold' : 'normal',
               fontSize: '1.3em',
             }}
-            onClick={() => setActiveSection('Price & Discounts')}
+            onClick={() => setActiveSection('Price Management')}
           >
-            Price & Discounts
+            Price Management
           </div>
 
           <List style={{ paddingLeft: '10px', marginBottom: '10px' }}>
             <ListItem>Set prices for new products</ListItem>
-            <ListItem>Notify users about discounts</ListItem>
+            {/* <ListItem>Notify users about discounts</ListItem> */}
           </List>
 
           <Divider style={{ marginBottom: '10px' }} />

--- a/frontend/src/pages/SalesManagerPage.js
+++ b/frontend/src/pages/SalesManagerPage.js
@@ -236,6 +236,29 @@ const SalesManagerPage = () => {
     }
   }, [activeSection, returnsFilter]);
 
+  const updateReturnStatus = async (returnId, newStatus) => {
+    try {
+      const token = localStorage.getItem('token');
+      await axios.patch(
+        `${API_URL}/returns/${returnId}`,
+        { status: newStatus },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      // Refresh the returns list after updating
+      const response = await axios.get(`${API_URL}/returns`, {
+        headers: { Authorization: `Bearer ${token}` },
+        params: returnsFilter ? { status: returnsFilter } : {},
+      });
+      setReturns(response.data);
+    } catch (err) {
+      alert('Failed to update return status. Please try again.');
+    }
+  };
+
   const handleLogout = () => {
     localStorage.removeItem("token");
     navigate("/");
@@ -515,13 +538,32 @@ const SalesManagerPage = () => {
                               <div><strong>Status:</strong> {ret.status}</div>
                               <div><strong>Order ID:</strong> {ret.order_id}</div>
                               <div><strong>User ID:</strong> {ret.user_id}</div>
-                              {/* <div><strong>Quantity:</strong> {ret.quantity}</div> */}
                               <div><strong>Refund Amount:</strong> {ret.refund_amount ?? 'N/A'}</div>
                               <div><strong>Requested At:</strong> {new Date(ret.request_date).toLocaleString()}</div>
                             </>
                           }
                         />
-                        {/* Approve/Reject buttons will be added later */}
+                        {/* Approve/Reject buttons */}
+                        <div style={{ display: 'flex', gap: '10px', marginTop: '10px' }}>
+                          {/* Approve Button */}
+                          <Button
+                            variant="contained"
+                            color="success"
+                            disabled={ret.status === 'approved'}
+                            onClick={() => updateReturnStatus(ret.return_id, 'approved')}
+                          >
+                            Approve
+                          </Button>
+                          {/* Reject Button */}
+                          <Button
+                            variant="contained"
+                            color="error"
+                            disabled={ret.status === 'approved' || ret.status === 'rejected'}
+                            onClick={() => updateReturnStatus(ret.return_id, 'rejected')}
+                          >
+                            Reject
+                          </Button>
+                        </div>
                       </ListItem>
                     ))}
                   </List>

--- a/frontend/src/pages/SalesManagerPage.js
+++ b/frontend/src/pages/SalesManagerPage.js
@@ -509,13 +509,13 @@ const SalesManagerPage = () => {
                         }}
                       >
                         <ListItemText
-                          primary={`Return ID: ${ret.return_id} | Order ID: ${ret.order_id}`}
+                          primary={`Return ID: ${ret.return_id}`}
                           secondary={
                             <>
                               <div><strong>Status:</strong> {ret.status}</div>
-                              <div><strong>Order Item ID:</strong> {ret.order_item_id}</div>
+                              <div><strong>Order ID:</strong> {ret.order_id}</div>
                               <div><strong>User ID:</strong> {ret.user_id}</div>
-                              <div><strong>Quantity:</strong> {ret.quantity}</div>
+                              {/* <div><strong>Quantity:</strong> {ret.quantity}</div> */}
                               <div><strong>Refund Amount:</strong> {ret.refund_amount ?? 'N/A'}</div>
                               <div><strong>Requested At:</strong> {new Date(ret.request_date).toLocaleString()}</div>
                             </>

--- a/frontend/src/pages/SalesManagerPage.js
+++ b/frontend/src/pages/SalesManagerPage.js
@@ -537,6 +537,23 @@ const SalesManagerPage = () => {
           </List>
 
           <Divider style={{ marginBottom: '10px' }} />
+
+          <div
+            style={{
+              cursor: 'pointer',
+              marginBottom: '10px',
+              color: activeSection === 'Return Requests' ? '#1976d2' : 'inherit',
+              fontWeight: activeSection === 'Return Requests' ? 'bold' : 'normal',
+              fontSize: '1.3em',
+            }}
+            onClick={() => setActiveSection('Return Requests')}
+          >
+            Return Requests
+          </div>
+          <List style={{ paddingLeft: '10px', marginBottom: '10px' }}>
+            <ListItem>Manage Returns</ListItem>
+          </List>
+          <Divider style={{ marginBottom: '10px' }} />
           
           <Typography
             variant="body1"


### PR DESCRIPTION
# Overview
Mainly in reference to #228 but with many other stuff.

cc. @zeynepyaman 

# Info
## Remove Old `returns` Table
```sql
DROP TABLE IF EXISTS returns;
```

## Updated Table
```sql
CREATE TABLE IF NOT EXISTS returns (
  return_id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
  order_id BIGINT UNSIGNED NOT NULL,
  user_id INT,
  refund_amount DECIMAL(10,2),
  status ENUM('pending', 'approved', 'rejected') DEFAULT 'pending',
  request_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
  FOREIGN KEY (order_id) REFERENCES orders(order_id) ON DELETE CASCADE,
  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE SET NULL
);
```

And remake it via:

```sql
SOURCE /.../cs308-project/backend/src/database/returns_schema.sql
```

Make sure you have it now:

```sql
select * from returns;
```

## Backend Logic
So as an example, I knew I had this order from an account:
![image](https://github.com/user-attachments/assets/87b3c5a7-de63-42a2-952d-46f18e053cf2)

![image](https://github.com/user-attachments/assets/66f9951f-8464-4f68-815c-28993271012c)

And therefore, I decided to insert a new row into `returns` table to simulate the action of this customer making a return request:
```sql
INSERT INTO returns (order_id, user_id, refund_amount)
VALUES (23, 46, 40.00);
```

And so:
```
mysql> select * from returns;
+-----------+----------+---------+---------------+---------+---------------------+
| return_id | order_id | user_id | refund_amount | status  | request_date        |
+-----------+----------+---------+---------------+---------+---------------------+
|         1 |       23 |      46 |         40.00 | pending | 2025-05-21 07:55:00 |
+-----------+----------+---------+---------------+---------+---------------------+
1 row in set (0,00 sec)
```

And on sales manager's page:
![image](https://github.com/user-attachments/assets/2763fc92-ace0-4d92-bb65-cbea1e005a5b)

Let's see if stock is updated or not. I know the customer ordered "Wool Sweater" with `product_id = 13`. Previously, the stock quantity was:

```
mysql> select * from product_variations where product_id=13;
+--------------+------------+---------------+---------+----------+----------------+
| variation_id | product_id | serial_number | size_id | color_id | stock_quantity |
+--------------+------------+---------------+---------+----------+----------------+
|           58 |         13 | SN32-1        |       1 |        4 |              0 |
|           59 |         13 | SN32-2        |       2 |        4 |            147 |
|           60 |         13 | SN32-3        |       3 |        4 |              5 |
|           61 |         13 | SN32-4        |       4 |        4 |             20 |
|           62 |         13 | SN32-5        |       5 |        4 |             50 |
+--------------+------------+---------------+---------+----------+----------------+
```

Now it's:
```
mysql> select * from product_variations where product_id=13;
+--------------+------------+---------------+---------+----------+----------------+
| variation_id | product_id | serial_number | size_id | color_id | stock_quantity |
+--------------+------------+---------------+---------+----------+----------------+
|           58 |         13 | SN32-1        |       1 |        4 |              0 |
|           59 |         13 | SN32-2        |       2 |        4 |            148 |
|           60 |         13 | SN32-3        |       3 |        4 |              5 |
|           61 |         13 | SN32-4        |       4 |        4 |             20 |
|           62 |         13 | SN32-5        |       5 |        4 |             50 |
+--------------+------------+---------------+---------+----------+----------------+
5 rows in set (0,00 sec)
```

As you can see, for `variation_id = 59`, the `stock_quantity` went from 147 to 148 after a successful/approved return. So stock gets updated correctly too.

### Accepting a Return Request
So now, let's test with curl:
```
curl -X PATCH http://localhost:5000/api/returns/1 \
  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0OCwicm9sZSI6InNhbGVzTWFuYWdlciIsImlhdCI6MTc0NzgwMzQ0NywiZXhwIjoxNzQ3ODE0MjQ3fQ.OyR7QkTjKdWMQArOVeN9Dpl6CmkNg5UBG-ROIUxUNoM" \
  -H "Content-Type: application/json" \
  -d '{"status":"approved"}'
```
> I'm writing this as I'm making the button for sales manager. This will have a button, don't worry.

Gives us:
```json
{
  "message":"Return status updated"
}
```

And also:
```
-- BEFORE
mysql> select * from returns;
+-----------+----------+---------+---------------+---------+---------------------+
| return_id | order_id | user_id | refund_amount | status  | request_date        |
+-----------+----------+---------+---------------+---------+---------------------+
|         1 |       23 |      46 |         40.00 | pending | 2025-05-21 07:55:00 |
+-----------+----------+---------+---------------+---------+---------------------+
1 row in set (0,00 sec)

-- AFTER
mysql> select * from returns;
+-----------+----------+---------+---------------+----------+---------------------+
| return_id | order_id | user_id | refund_amount | status   | request_date        |
+-----------+----------+---------+---------------+----------+---------------------+
|         1 |       23 |      46 |         40.00 | approved | 2025-05-21 07:55:00 |
+-----------+----------+---------+---------------+----------+---------------------+
1 row in set (0,00 sec)
```

The customer now sees:
![image](https://github.com/user-attachments/assets/d276cdb8-c148-46d2-aa41-3e20b3b45f62)
![image](https://github.com/user-attachments/assets/922d19cb-dd15-4e80-bb47-d033943ac906)

> I included "Order Status: ..." so that if it's refunded and the blue progress bar goes away, at least they can see it's refunded.

And manager sees:
![image](https://github.com/user-attachments/assets/e37e9812-6c1d-43cc-93a3-fc575b018c4d)

 ### Rejecting a Return Request
Now let's try the same thing but this time, we reject it. For this example:
![image](https://github.com/user-attachments/assets/d0ff7669-b172-474f-ac0c-4139f868ff86)

Simulate return action from customer's side:
```sql
INSERT INTO returns (order_id, user_id, refund_amount)
VALUES (20, 46, 154.99);
```

And:
![image](https://github.com/user-attachments/assets/7d8a1822-754d-4f2f-9ad0-5e014c3539cb)

So now let's simulate rejection of return with ID 2:

```
curl -X PATCH http://localhost:5000/api/returns/2 \
  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0OCwicm9sZSI6InNhbGVzTWFuYWdlciIsImlhdCI6MTc0NzgwMzQ0NywiZXhwIjoxNzQ3ODE0MjQ3fQ.OyR7QkTjKdWMQArOVeN9Dpl6CmkNg5UBG-ROIUxUNoM" \
  -H "Content-Type: application/json" \
  -d '{"status":"rejected"}'
```

Response:
```json
{
  "message":"Return status updated"
}
```

And on the pages, the manager sees:
![image](https://github.com/user-attachments/assets/b9e4cc94-ed0f-489d-a822-6cdccd1bd7b1)

And the customer's view doesn't change since the product is still delivered of course, but their request for return is rejected. So nothing should change:
![image](https://github.com/user-attachments/assets/e5891137-c3fd-4c63-a1b2-c2a3a650eae4)

Checking the stock should not reflect any changes because nothing was returned. Since the order had two items, one of which being "Sporty Sandals" with `product_id = 14`, let's double check the stock. Before:

```
mysql> select * from product_variations where product_id=14;
+--------------+------------+---------------+---------+----------+----------------+
| variation_id | product_id | serial_number | size_id | color_id | stock_quantity |
+--------------+------------+---------------+---------+----------+----------------+
|           63 |         14 | SN33-1        |       7 |        3 |            100 |
|           64 |         14 | SN33-2        |       8 |        3 |            176 |
|           65 |         14 | SN33-3        |       9 |        3 |              6 |
|           66 |         14 | SN33-4        |      10 |        3 |              0 |
+--------------+------------+---------------+---------+----------+----------------+
```

And after the rejection of return request:
```
mysql> select * from product_variations where product_id=14;
+--------------+------------+---------------+---------+----------+----------------+
| variation_id | product_id | serial_number | size_id | color_id | stock_quantity |
+--------------+------------+---------------+---------+----------+----------------+
|           63 |         14 | SN33-1        |       7 |        3 |            100 |
|           64 |         14 | SN33-2        |       8 |        3 |            176 |
|           65 |         14 | SN33-3        |       9 |        3 |              6 |
|           66 |         14 | SN33-4        |      10 |        3 |              0 |
+--------------+------------+---------------+---------+----------+----------------+
```

All 4 numbers are the same (100, 176, 6, 0). So we're good.

## Frontend Buttons
Since backend works fine now, here's what the buttons look like (they're connected to those backend endpoints). For the sake of visuals, I added another row to simulate a return request from a customer so that we'd have all 3 `status` enums:

```sql
insert into returns (order_id, user_id, refund_amount) values (4, 2, 45.00);
```

And now:
![image](https://github.com/user-attachments/assets/6a705744-43b1-414b-863e-2a28732e9c6d)

Basically, if you "approve" a return request, it will update it and no longer can the manager change it. But if you "reject" a return request, you can still approve it later (for example a customer provides more evidence on why).

Now I rejected the third return request, so let's see if it's reflected:
![image](https://github.com/user-attachments/assets/24e17780-62cd-4848-a1da-40f04cecee02)

It's updated on frontend. On DB:

```
-- BEFORE
mysql> select * from returns;
+-----------+----------+---------+---------------+----------+---------------------+
| return_id | order_id | user_id | refund_amount | status   | request_date        |
+-----------+----------+---------+---------------+----------+---------------------+
|         1 |       23 |      46 |         40.00 | approved | 2025-05-21 07:55:00 |
|         2 |       20 |      46 |        154.99 | rejected | 2025-05-21 08:13:17 |
|         3 |        4 |       2 |         45.00 | pending  | 2025-05-21 08:37:22 |
+-----------+----------+---------+---------------+----------+---------------------+
3 rows in set (0,00 sec)

-- AFTER
mysql> select * from returns;
+-----------+----------+---------+---------------+----------+---------------------+
| return_id | order_id | user_id | refund_amount | status   | request_date        |
+-----------+----------+---------+---------------+----------+---------------------+
|         1 |       23 |      46 |         40.00 | approved | 2025-05-21 07:55:00 |
|         2 |       20 |      46 |        154.99 | rejected | 2025-05-21 08:13:17 |
|         3 |        4 |       2 |         45.00 | rejected | 2025-05-21 08:37:22 |
+-----------+----------+---------+---------------+----------+---------------------+
3 rows in set (0,00 sec)
```

The customer still sees the same page:
![image](https://github.com/user-attachments/assets/b26623a3-d3d9-4ae8-9ce9-ab4f0b1fa9e4)

And the stock hasn't changed:

```
mysql> select * from order_items  where order_id=4;
+---------------+----------+------------+--------------+----------+-------------------+
| order_item_id | order_id | product_id | variation_id | quantity | price_at_purchase |
+---------------+----------+------------+--------------+----------+-------------------+
|             6 |        4 |          2 |            7 |        1 |             45.00 |
+---------------+----------+------------+--------------+----------+-------------------+
1 row in set (0,00 sec)
```

Before:
```
mysql> select * from product_variations where variation_id=7;
+--------------+------------+---------------+---------+----------+----------------+
| variation_id | product_id | serial_number | size_id | color_id | stock_quantity |
+--------------+------------+---------------+---------+----------+----------------+

|            7 |          2 | SN11-2        |       2 |        4 |             90 |
+--------------+------------+---------------+---------+----------+----------------+
```

After:
```
mysql> select * from product_variations where variation_id=7;
+--------------+------------+---------------+---------+----------+----------------+
| variation_id | product_id | serial_number | size_id | color_id | stock_quantity |
+--------------+------------+---------------+---------+----------+----------------+
|            7 |          2 | SN11-2        |       2 |        4 |             90 |
+--------------+------------+---------------+---------+----------+----------------+
```

> Still 90 in stock, because rejection doesn't affect stock.

And let's approve the same thing:
![image](https://github.com/user-attachments/assets/78a9ea5e-022f-4e9f-8489-823f18fabb11)

The customer now sees this:
![image](https://github.com/user-attachments/assets/bb78bb63-53b0-4296-9538-0475ee38c542)

And the stock gets updated correctly:
```
-- BEFORE
mysql> select * from product_variations where variation_id=7;
+--------------+------------+---------------+---------+----------+----------------+
| variation_id | product_id | serial_number | size_id | color_id | stock_quantity |
+--------------+------------+---------------+---------+----------+----------------+
|            7 |          2 | SN11-2        |       2 |        4 |             90 |
+--------------+------------+---------------+---------+----------+----------------+
1 row in set (0,00 sec)

-- AFTER
mysql> select * from product_variations where variation_id=7;
+--------------+------------+---------------+---------+----------+----------------+
| variation_id | product_id | serial_number | size_id | color_id | stock_quantity |
+--------------+------------+---------------+---------+----------+----------------+
|            7 |          2 | SN11-2        |       2 |        4 |             91 |
+--------------+------------+---------------+---------+----------+----------------+
1 row in set (0,00 sec)
```