### PR TITLE
Order cancellation

### DIFF
--- a/backend/src/routes/orderRoutes.js
+++ b/backend/src/routes/orderRoutes.js
@@ -8,6 +8,7 @@ router.post("/", authMiddleware, orderController.createOrder);
 router.get("/user", authMiddleware, orderController.getOrdersByUser);
 router.get("/with-items/:id", authMiddleware, orderController.getOrderWithItems);
 router.get("/orders-between-dates", authMiddleware, orderController.getOrdersBetweenDates);
+router.patch("/:orderId/cancel", authMiddleware, orderController.cancelOrder);
 router.get("/:id", orderController.getOrderById);
 router.patch("/:id/status", orderController.updateOrderStatus);
 router.delete("/:id", orderController.deleteOrder);

--- a/frontend/src/pages/OrderStatusPage.js
+++ b/frontend/src/pages/OrderStatusPage.js
@@ -12,14 +12,57 @@ import {
   Button,
   Paper,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton, 
+  Snackbar,
+  Alert,
 } from "@mui/material";
+import {
+  CheckCircle as CheckCircleIcon,
+  Cancel as CancelIcon,
+  LocalShipping as LocalShippingIcon,
+  DoneAll as DoneAllIcon,
+} from "@mui/icons-material";
 import axios from "axios";
 import Footer from "../components/Footer";
 import "./OrderStatusPage.css";
 
 const API_URL = process.env.REACT_APP_API_URL;
 
+// Define the standard status steps for the stepper
 const statusSteps = ["processing", "in-transit", "delivered"];
+
+// Custom Step Icon Component for the Stepper
+// This component will render different icons based on step status and order cancellation.
+const CustomStepIcon = ({ active, completed, icon, error, orderStatus }) => {
+  // Styles for the icons
+  const iconStyles = {
+    fontSize: 24, // Adjusted for the stepper icon
+    color: "#9e9e9e", // Default grey
+  };
+
+  // Render a red 'X' icon if the order is cancelled and this is the first step
+  if (orderStatus === 'cancelled' && icon === 1) {
+    return <CancelIcon sx={{ ...iconStyles, color: "#f44336" }} />; // Red color for cancelled
+  }
+
+  // Render standard icons based on step completion/activity
+  switch (icon) {
+    case 1: // Processing step
+      return <CheckCircleIcon sx={{ ...iconStyles, color: completed || active ? "#4caf50" : "#9e9e9e" }} />;
+    case 2: // In-transit step
+      return <LocalShippingIcon sx={{ ...iconStyles, color: completed || active ? "#ff9800" : "#9e9e9e" }} />;
+    case 3: // Delivered step
+      return <DoneAllIcon sx={{ ...iconStyles, color: completed || active ? "#2196f3" : "#9e9e9e" }} />;
+    default:
+      return null;
+  }
+};
+
 
 const OrderStatusPage = () => {
   const { orderId } = useParams();
@@ -28,20 +71,26 @@ const OrderStatusPage = () => {
   const [orderDetails, setOrderDetails] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [showCancelConfirmation, setShowCancelConfirmation] = useState(false);
+  const [cancelMessage, setCancelMessage] = useState({ type: '', text: '' }); // type: 'success' or 'error'
 
+  // Effect to fetch order details when the component mounts or orderId changes
   useEffect(() => {
     const fetchOrderDetails = async () => {
       try {
+        setLoading(true); // Set loading to true before fetching
         const response = await axios.get(`${API_URL}/orders/with-items/${orderId}`, {
           headers: {
             Authorization: `Bearer ${localStorage.getItem("token")}`,
           },
         });
         setOrderDetails(response.data);
-        setLoading(false);
+        setError(null); // Clear any previous errors
       } catch (err) {
-        setError("Error loading order details");
-        setLoading(false);
+        console.error("Error loading order details:", err);
+        setError("Error loading order details. Please try again.");
+      } finally {
+        setLoading(false); // Set loading to false after fetching
       }
     };
 
@@ -53,23 +102,77 @@ const OrderStatusPage = () => {
       console.error("orderDate is undefined or invalid:", orderDate);
       return null;
     }
-
     const date = new Date(orderDate);
     if (isNaN(date)) {
       console.error("Invalid date:", orderDate);
       return null;
     }
-
     date.setDate(date.getDate() + 7);
     return date;
   };
 
+  // Function to format a date string into DD/MM/YYYY
   const formatDate = (dateString) => {
     const date = new Date(dateString);
     const day = String(date.getDate()).padStart(2, "0");
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const year = date.getFullYear();
-    return `${day}/${month}/${year}`;
+    return `${year}-${month}-${day}`; 
+  };
+
+  // Handler for when the "Cancel Order" button is clicked
+  const handleCancelOrderClick = () => {
+    if (orderDetails.order.status.toLowerCase() !== 'processing') {
+      // If order is not 'processing', show an error message
+      setCancelMessage({ type: 'error', text: "Order cannot be cancelled. Only processing orders are eligible for cancellation." });
+    } else {
+      // If eligible, show the confirmation pop-up
+      setShowCancelConfirmation(true);
+    }
+  };
+
+  // Handler for confirming the cancellation in the pop-up
+  const handleConfirmCancel = async () => {
+    setShowCancelConfirmation(false); // Close the confirmation pop-up
+    setLoading(true); // Show loading indicator
+
+    try {
+      await axios.patch(`${API_URL}/orders/${orderId}/cancel`, {}, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+      });
+      // Update the order status in the local state to 'cancelled'
+      setOrderDetails(prevDetails => ({
+        ...prevDetails,
+        order: {
+          ...prevDetails.order,
+          status: 'cancelled'
+        }
+      }));
+      // Changed the success message here
+      setCancelMessage({ type: 'success', text: "Order cancelled successfully." });
+      setError(null); // Clear any previous errors
+    } catch (err) {
+      console.error("Error cancelling order:", err);
+      const errorMessage = err.response?.data?.message || "Failed to cancel order. Please try again.";
+      setCancelMessage({ type: 'error', text: errorMessage });
+    } finally {
+      setLoading(false); // Hide loading indicator
+    }
+  };
+
+  // Handler for closing the confirmation pop-up without cancelling
+  const handleCloseConfirmation = () => {
+    setShowCancelConfirmation(false);
+  };
+
+  // Handler for closing the Snackbar message
+  const handleCloseSnackbar = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setCancelMessage({ type: '', text: '' });
   };
 
   if (loading) {
@@ -81,94 +184,161 @@ const OrderStatusPage = () => {
   }
 
   if (error) {
-    return <Typography color="error">{error}</Typography>;
+    return <Typography color="error" sx={{ textAlign: 'center', mt: 4 }}>{error}</Typography>;
   }
 
+
   if (!orderDetails) {
-    return <Typography>No order details available</Typography>;
+    return <Typography sx={{ textAlign: 'center', mt: 4 }}>No order details available.</Typography>;
   }
 
   const { order, items } = orderDetails;
   const estimatedDelivery = calculateEstimatedDelivery(order.order_date);
+
+  // Determine the active step for the stepper
+  // If order is cancelled, set activeStep to -1 so no step is "active" in the linear flow,
+  // but we'll use the error prop on the first step to show the 'X'.
   const currentStep = statusSteps.indexOf(order.status.toLowerCase());
 
   return (
     <>
-    <div className="order-status-container"> 
-      <Box sx={{ maxWidth: 800, mx: "auto", p: 4 }}>
-        <Paper elevation={3} className="order-status-paper">
-          <Typography variant="h6" gutterBottom>
-            Order Details
-          </Typography>
-          <Typography>Order Number: {order.order_id}</Typography>
-          <Typography>Order Date: {formatDate(order.order_date)}</Typography>
-          <Typography>Total Price: ${order.total_price}</Typography>
-          <Typography>Order Status: {order.status}</Typography>
+      <div className="order-status-container">
+        <Box sx={{ maxWidth: 800, mx: "auto", p: 4 }}>
+          <Paper elevation={3} className="order-status-paper">
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Order Details
+              </Typography>
+              {/* Cancel Order Button */}
+              {order.status.toLowerCase() !== 'cancelled' && ( // Only show if not already cancelled
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={handleCancelOrderClick}
+                  sx={{ ml: 'auto' }} // Pushes the button to the right
+                >
+                  Cancel Order
+                </Button>
+              )}
+            </Box>
 
-          <Box sx={{ my: 4 }}>
-            <Stepper activeStep={currentStep} alternativeLabel>
-              {statusSteps.map((label) => (
-                <Step key={label}>
-                  <StepLabel>{label.charAt(0).toUpperCase() + label.slice(1)}</StepLabel>
-                </Step>
+            {/* Display cancellation message (error or success) */}
+            {cancelMessage.text && (
+              <Alert severity={cancelMessage.type} sx={{ mb: 2 }}>
+                {cancelMessage.text}
+              </Alert>
+            )}
+
+            <Typography>Order Number: {order.order_id}</Typography>
+            <Typography>Order Date: {formatDate(order.order_date)}</Typography>
+            <Typography>Total Price: ${order.total_price}</Typography>
+            {/* Display current order status */}
+            <Typography>Order Status: <span style={{ fontWeight: 'bold', color: order.status.toLowerCase() === 'cancelled' ? '#f44336' : 'inherit' }}>{order.status}</span></Typography>
+
+            <Box sx={{ my: 4 }}>
+              {/* Conditionally render Stepper or a simple "Cancelled" message */}
+              {order.status.toLowerCase() !== 'cancelled' ? (
+                <Stepper activeStep={currentStep} alternativeLabel>
+                  {statusSteps.map((label) => (
+                    <Step key={label}>
+                      <StepLabel
+                        StepIconComponent={(props) => (
+                          <CustomStepIcon
+                            {...props}
+                            orderStatus={order.status.toLowerCase()}
+                          />
+                        )}
+                      >
+                        {label.charAt(0).toUpperCase() + label.slice(1)}
+                      </StepLabel>
+                    </Step>
+                  ))}
+                </Stepper>
+              ) : (
+                // Custom display for cancelled order
+                <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 4 }}>
+                  <CancelIcon sx={{ fontSize: 48, color: "#f44336", mb: 1 }} /> {/* Adjusted font size here */}
+                  <Typography variant="h5" color="error">Order Cancelled</Typography>
+                </Box>
+              )}
+            </Box>
+
+            <Typography variant="h6" gutterBottom>
+              Shipping Information
+            </Typography>
+            <Typography>Delivery Address: {order.delivery_address}</Typography>
+
+            <Typography variant="h6" gutterBottom sx={{ mt: 3 }}>
+              Items in Order
+            </Typography>
+            <List>
+              {items.map((item) => (
+                <ListItem key={item.order_item_id}>
+                  <ListItemText
+                    primary={`${item.product_name} (x${item.quantity})`}
+                    secondary={`Price at Purchase: $${item.price_at_purchase}`}
+                  />
+                </ListItem>
               ))}
-            </Stepper>
-          </Box>
+            </List>
 
-          <Typography variant="h6" gutterBottom>
-            Shipping Information
-          </Typography>
-          <Typography>Delivery Address: {order.delivery_address}</Typography>
+            <Typography variant="h6" gutterBottom>
+              Estimated Delivery
+            </Typography>
+            <Typography>
+              {estimatedDelivery ? formatDate(estimatedDelivery) : "N/A"}
+            </Typography>
 
-          <Typography variant="h6" gutterBottom sx={{ mt: 3 }}>
-            Items in Order
-          </Typography>
-          <List>
-            {items.map((item) => (
-              <ListItem key={item.order_item_id}>
-                <ListItemText
-                  primary={`${item.product_name} (x${item.quantity})`}
-                  secondary={`Price at Purchase: $${item.price_at_purchase}`}
-                />
-              </ListItem>
-            ))}
-          </List>
+            <Box sx={{ display: "flex", gap: 2, mt: 3 }}>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={() => navigate("/")}
+                sx={{ flex: 1 }}
+              >
+                Back to Home
+              </Button>
+              <Button
+                variant="contained"
+                sx={{
+                  backgroundColor: "#9c27b0", 
+                  color: "#fff",
+                  flex: 1,
+                  "&:hover": { backgroundColor: "#7b1fa2" }, 
+                }}
+                onClick={() => navigate("/profile")}
+              >
+                Back to Profile
+              </Button>
+            </Box>
+          </Paper>
+        </Box>
+      </div>
 
-          <Typography variant="h6" gutterBottom>
-            Estimated Delivery
-          </Typography>
-          <Typography>
-            {estimatedDelivery ? formatDate(estimatedDelivery) : "N/A"}
-          </Typography>
+      <Footer />
 
-          {/* navigation buttons to landing page and/or profile page */}
-          <Box sx={{ display: "flex", gap: 2, mt: 3 }}>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={() => navigate("/")}
-              sx={{ flex: 1 }}
-            >
-              Back to Home
-            </Button>
-            <Button
-              variant="contained"
-              sx={{
-                backgroundColor: "#9c27b0", // MUI purple[500]
-                color: "#fff",
-                flex: 1,
-                "&:hover": { backgroundColor: "#7b1fa2" }, // MUI purple[700]
-              }}
-              onClick={() => navigate("/profile")}
-            >
-              Back to Profile
-            </Button>
-          </Box>
-        </Paper>
-      </Box>
-    </div>
-
-    <Footer />
+      {/* Confirmation Dialog for Cancellation */}
+      <Dialog
+        open={showCancelConfirmation}
+        onClose={handleCloseConfirmation}
+        aria-labelledby="cancel-order-dialog-title"
+        aria-describedby="cancel-order-dialog-description"
+      >
+        <DialogTitle id="cancel-order-dialog-title">Confirm Order Cancellation</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="cancel-order-dialog-description">
+            Are you sure you want to cancel this order? This action cannot be undone, and the order will be marked as 'cancelled'.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseConfirmation} color="primary">
+            No, Keep Order
+          </Button>
+          <Button onClick={handleConfirmCancel} color="error" autoFocus>
+            Yes, Cancel Order
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };


### PR DESCRIPTION
Order cancellation full stack

Only allows if status is processing, returns back stock after successful cancellation.

### 1) Backend

PATCH http://localhost:5001/api/orders/33/cancel

```
curl -X PATCH http://localhost:5001/api/orders/33/cancel \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"
```
<img width="1009" alt="Screenshot 2025-05-21 at 19 23 09" src="https://github.com/user-attachments/assets/653419fa-7311-44a1-8504-3a8b55b3127b" />


Can't cancel 34 because it's in-transit:
<img width="801" alt="Screenshot 2025-05-21 at 19 24 05" src="https://github.com/user-attachments/assets/7ec9bf1a-6e6b-44c4-a203-a3299ec25cd7" />

<img width="1024" alt="Screenshot 2025-05-21 at 19 19 19" src="https://github.com/user-attachments/assets/529fda8d-5ac3-4df6-bbb5-d6b4b3854392" />

Before cancellation stock:

<img width="799" alt="Screenshot 2025-05-21 at 22 11 39" src="https://github.com/user-attachments/assets/6cef7e60-c39b-4146-b045-a4a7837ca7e5" />


After cancellation stock:
<img width="801" alt="Screenshot 2025-05-21 at 19 24 05" src="https://github.com/user-attachments/assets/c07df496-24ca-4fb7-8a08-b15094a55db3" />

### 2) Frontend

NOTE: There is also new icons for order statuses. 


Doesn't allow cancellation if status is not processing.

<img width="801" alt="cant-cancel-in-transit" src="https://github.com/user-attachments/assets/d57b235e-b5c4-4c52-a90c-221f287df9cf" />

<img width="801" alt="cant-cancel-delivered" src="https://github.com/user-attachments/assets/82d6582a-b768-4fe5-8450-60e862d17d18" />




Before cancelling order items stock:
<img width="663" alt="before-cancelling-stock" src="https://github.com/user-attachments/assets/d27b2869-bfcf-46c6-b9c0-5f671a7d714f" />



When clicked cancel order button this pops up :

<img width="799" alt="cancel-order-pop-up" src="https://github.com/user-attachments/assets/b1ea4025-30ee-4a71-9d23-f18645e927cb" />


If yes is selected, order is successfully cancelled (nothing happens if you select no):
<img width="799" alt="order cancelled" src="https://github.com/user-attachments/assets/9960b3bb-e73b-4fdb-a50a-ff2de1fc1906" />


Stock after cancellation:

<img width="799" alt="stock-after-cancellation" src="https://github.com/user-attachments/assets/2abdcdc5-aa1b-4a26-aae0-6b9039132d77" />








