### PR TITLE
createReturn updated + returns frontend + fix for issue #249

### DIFF
--- a/backend/src/controllers/orderController.js
+++ b/backend/src/controllers/orderController.js
@@ -423,6 +423,13 @@ exports.cancelOrder = async (req, res) => {
     if (order.status === 'processing') {
       await Order.updateStatus(orderId, 'cancelled');
 
+      // Delete the delivery record associated with the cancelled order.
+      // This is done because altering the 'deliveries' table schema is not ideal at this point.
+      await pool.query(
+        `DELETE FROM deliveries WHERE order_id = ?`,
+        [orderId]
+      );
+
       // Fetch order items for the cancelled order
       const items = await OrderItem.getByOrderId(orderId);
 

--- a/backend/src/controllers/returnsController.js
+++ b/backend/src/controllers/returnsController.js
@@ -1,24 +1,57 @@
 const Returns = require('../models/returns');
 const ProductVariations = require('../models/productVariations');
+const Order = require('../models/order');
 const db = require('../config/database');
 
 exports.createReturn = async (req, res) => {
   try {
     const userId = req.user.user_id;
-    const { order_id, refund_amount } = req.body;
+    // Removed refund_amount from req.body as it will be pulled from the order
+    const { order_id } = req.body;
     // no more order_item_id and quantity in the returns table
 
     if (!order_id) {
       return res.status(400).json({ message: "order_id is required" });
     }
 
+    // 1. Fetch the order details
+    const order = await Order.getById(order_id);
+
+    // Check if the order exists
+    if (!order) {
+      return res.status(404).json({ message: "Order not found." });
+    }
+
+    // Ensure the user owns the order (security check)
+    if (order.user_id !== userId) {
+      return res.status(403).json({ message: "You are not authorized to create a return for this order." });
+    }
+
+    // 2. Check order status: Must be 'delivered'
+    if (order.status.toLowerCase() !== 'delivered') {
+      return res.status(400).json({ message: `Return requests can only be made for 'delivered' orders. Current status: ${order.status}.` });
+    }
+
+    // 3. Check time limit: Less than 30 days since order_date
+    const orderDate = new Date(order.order_date);
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    if (orderDate < thirtyDaysAgo) {
+      return res.status(400).json({ message: "Return requests can only be made within 30 days of the order date." });
+    }
+
+    // Use the total_price from the fetched order as the refund_amount
+    const refund_amount = order.total_price;
+
+    // If all checks pass, proceed with creating the return request
     const returnId = await Returns.create({
       order_id,
-      refund_amount,
+      refund_amount, // Now using the total_price from the order
       user_id: userId
     });
 
-    res.status(201).json({ message: "Return request created", return_id: returnId });
+    res.status(201).json({ message: "Return request created successfully", return_id: returnId });
   } catch (err) {
     console.error("Create return failed:", err);
     res.status(500).json({ error: err.message });

--- a/backend/src/controllers/returnsController.js
+++ b/backend/src/controllers/returnsController.js
@@ -41,6 +41,16 @@ exports.createReturn = async (req, res) => {
       return res.status(400).json({ message: "Return requests can only be made within 30 days of the order date." });
     }
 
+    const [existingReturns] = await db.execute(
+      `SELECT return_id, status FROM returns WHERE order_id = ?`,
+      [order_id]
+    );
+
+    // If any return request exists for this order, prevent a new request.
+    if (existingReturns.length > 0) {
+      return res.status(400).json({ message: `A return request for this order already exists with status: ${existingReturns[0].status}.` });
+    }
+
     // Use the total_price from the fetched order as the refund_amount
     const refund_amount = order.total_price;
 


### PR DESCRIPTION

### Returns

### 1) createReturn method updated

POST http://localhost:5001/api/returns
{
  "order_id": 43
}

```
curl -X POST http://localhost:5001/api/returns \
  -H "Authorization: Bearer YOUR_JWT_TOKEN_HERE" \
  -H "Content-Type: application/json" \
  -d '{"order_id": 43}'

```
Doesn't allow if order status is not delivered


<img width="799" alt="order-processing cant-return" src="https://github.com/user-attachments/assets/0331f559-f130-45b7-baa7-7ceea734700f" />
<img width="799" alt="order-in-transit-cant-return" src="https://github.com/user-attachments/assets/08d76a62-96b7-4046-af2f-7fac4a87a236" />

<img width="1014" alt="cant return processing" src="https://github.com/user-attachments/assets/dccc65f4-d8bd-4636-ad18-d826c624f4e5" />
<img width="1014" alt="cant return in transit" src="https://github.com/user-attachments/assets/75c996c3-c1fd-40e3-a932-dd0e079e5457" />


Doesn't allow if it's been more than 30 days since order created.
Manually update order_date:
```
UPDATE orders
SET order_date = '2025-04-01'
WHERE order_id = 42;
```
<img width="781" alt="manually updating date" src="https://github.com/user-attachments/assets/c31cdff5-1c37-4f1e-86d6-859c5b52d752" />


<img width="1004" alt="Screenshot 2025-05-22 at 00 27 11" src="https://github.com/user-attachments/assets/5e7fc70b-63b8-49e6-9944-f8eb7fa12fdc" />

Also fixed the issue of being able to request return multiple times, now you the user can only request once per order.

<img width="1034" alt="Screenshot 2025-05-22 at 01 38 27" src="https://github.com/user-attachments/assets/9a41370c-4575-4a41-a013-29f1c5689c57" />

<img width="1012" alt="Screenshot 2025-05-22 at 01 39 17" src="https://github.com/user-attachments/assets/e809f358-8a0e-4172-bee0-bb1f92381d52" />

Successful return request:
<img width="1014" alt="successful return req-postman" src="https://github.com/user-attachments/assets/692b8658-fa84-4a4c-93b9-8b2f06696bd6" />

<img width="600" alt="succesful return request" src="https://github.com/user-attachments/assets/16a0e8b2-7d27-4b84-a790-5dbccccdedfe" />

### 2) Returns Frontend

Doesn't allow if order status is not delivered
<img width="666" alt="return-in-transit" src="https://github.com/user-attachments/assets/5698568e-8c31-4448-938c-db2d0d4d0271" />


<img width="666" alt="cant-return-processing" src="https://github.com/user-attachments/assets/13bc228e-c9b8-4509-abe8-a28073cce709" />

Doesn't allow if it's been more than 30 days since order created.
Manually updated date again:
<img width="800" alt="updateing date2" src="https://github.com/user-attachments/assets/1bf6f684-5bd1-4914-899c-e60ea470c8b3" />

<img width="800" alt="return-30-days" src="https://github.com/user-attachments/assets/3a7beab7-8e85-48f5-9256-a0534e0a3c55" />


Also fixed the issue of being able to request return multiple times, now you the user can only request once per order.

<img width="637" alt="Screenshot 2025-05-22 at 01 38 15" src="https://github.com/user-attachments/assets/c1265cb8-680d-42ab-8626-4c49921ff78a" />

<img width="658" alt="Screenshot 2025-05-22 at 01 39 45" src="https://github.com/user-attachments/assets/f5a2782b-67da-4c74-bab4-15a59533ec48" />

When clicked request return button this pops up: 
<img width="658" alt="Screenshot 2025-05-22 at 01 40 47" src="https://github.com/user-attachments/assets/88ff0920-0239-441f-8ddd-555e3a9395b5" />


Successful return request:
<img width="658" alt="Screenshot 2025-05-22 at 01 40 55" src="https://github.com/user-attachments/assets/1dabcb98-d35f-42ac-b298-8c977c5606ce" />

Return request approved:
<img width="273" alt="Screenshot 2025-05-22 at 01 41 44" src="https://github.com/user-attachments/assets/d0becf4a-ff2f-490b-9c37-51fc8a57dd6e" />


<img width="643" alt="Screenshot 2025-05-22 at 01 43 27" src="https://github.com/user-attachments/assets/b8f50baf-08b6-4839-821a-62cb534a7274" />

### 3) Fix for issue #249 
As we don't want to alter tables at this point, we decided to go on with deleting the row belonging to the cancelled order from the deliveries table.

Created new order:

<img width="817" alt="new order fpr cancel" src="https://github.com/user-attachments/assets/e184eb60-2d09-4977-a173-2a1594131b16" />


Order is vislble at deliveries table and manager menu:
<img width="817" alt="Screenshot 2025-05-22 at 01 57 32" src="https://github.com/user-attachments/assets/2224158a-cacf-47dd-92ea-c7fdcdd4eb56" />

<img width="907" alt="Screenshot 2025-05-22 at 01 57 56" src="https://github.com/user-attachments/assets/ba6a8223-a47e-40d3-a7bf-c75260676576" />


Cancelled order:
<img width="733" alt="Screenshot 2025-05-22 at 01 58 36" src="https://github.com/user-attachments/assets/9a0cb99c-ee18-49d5-8a08-b30da0b45312" />


Order is gone from table and manager menu:
<img width="733" alt="Screenshot 2025-05-22 at 01 58 50" src="https://github.com/user-attachments/assets/ae81d2f3-37bd-4454-ba7f-23474b78940b" />


<img width="950" alt="Screenshot 2025-05-22 at 01 59 19" src="https://github.com/user-attachments/assets/a9cce843-d1c1-476a-82e0-232d0fc8b71d" />


